### PR TITLE
fix: correct manifest asset paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,114 +1,60 @@
-### VineStrike
+# VineStrike
 
-Isometric helicopter action built with TypeScript + Vite + Canvas 2D.
+VineStrike is a browser-based homage to classic isometric helicopter strike games. Everything runs in TypeScript with a lightweight ECS, Canvas 2D rendering, and a deterministic fixed-step loop.
 
-Codename VineStrike — an original homage to early-90s isometric action. All names, art, sounds, and code are original.
-
-### Tech
-
-- Vite + TypeScript (strict)
-- Canvas 2D (no WebGL)
-- ECS-lite architecture, deterministic fixed-timestep
-- 100% static hosting (GitHub Pages)
-
-### Getting Started
-
-Prerequisite: Node.js 18+
-
-Install
+## Quickstart
 
 ```bash
-npm ci
+npm install
+npm run dev -- --host
 ```
 
-Run (dev)
-
-```bash
-npm run dev
-```
-
-Open the URL printed by Vite (usually http://localhost:5173).
-
-Build
+Open the printed URL in Chrome or Firefox. For a production build:
 
 ```bash
 npm run build
 ```
 
-Outputs to `dist/`.
+## Controls
 
-Preview build
+- **WASD / Arrow Keys** – Fly the chopper
+- **Space / Left Mouse** – Primary cannon
+- **Shift / Right Mouse** – Rockets
+- **E / Middle Mouse / X** – Missiles
+- **R / Q / Tab** – Cycle weapons (1/2/3 for direct selection)
+- **Esc** – Pause / Resume / Back
+- **M** – Toggle mute
 
-```bash
-npm run preview
-```
-
-### Deploy (GitHub Pages)
-
-This repo auto-deploys on push to `main`.
-
-- Workflow builds and publishes `dist/` to the `gh-pages` branch.
-- Ensure Settings → Pages deploys from the `gh-pages` branch (root).
-- Asset URLs are relative via Vite `base: './'`.
-
-### Controls (Phase 0 placeholder)
-
-- WASD: movement
-- Mouse: aim
-- Esc: pause
-
-Remapping and full input schema will land in later phases.
-
-### Project Structure (high-level)
+## Project Structure
 
 ```
-/index.html
-/vite.config.ts
-/public/
+/index.html            Entry page and canvas
+/vite.config.ts        Vite configuration
 /src/
-  main.ts
-  core/ (ecs, math, time, input, audio, assets, util)
-  render/ (camera, iso, sprites, draw, debug)
-  world/ (tiles, collisions, pathing)
-  game/
-    components/
-    systems/
-    data/ (tilesets, maps, missions, entity-presets)
-    scenes/
-  ui/ (hud, menus, input-remap)
-  assets/
-/.github/workflows/gh-pages.yml
+  core/                ECS, timing, input, audio, utilities
+  game/                Components, systems, data
+  render/              Camera, isometric projection, sprite painters
+  ui/                  HUD, menus, bindings
+  world/               Tilemap helpers and sample map
+  main.ts              Game wiring and loop
+/public/               Favicon and manifest
 ```
 
-### License
+## Gameplay Notes
 
-- Code: MIT (see `LICENSE`)
-- Original assets in `src/assets/`: CC0 1.0 (see `src/assets/LICENSE`)
+- Waves spawn patrol drones and chaser gunships; difficulty ramps each wave.
+- The mission layer tracks static AAA/SAM objectives. Clear them and survive to win.
+- Helicopter health, ammo, and fuel are replenished at the central refuel pad.
+- Explosion, weapon, and engine audio are procedural and respect the mute toggle.
 
-### Phase Plan
+## Known Limitations
 
-- Phase 0 — Scaffold & Pages (this commit)
-- Phase 1 — Core Engine
-- Phase 2 — Iso Map + Camera
-- Phase 3 — Player Flight Model
-- Phase 4 — Weapons & Projectiles
-- Phase 5 — Enemies & AI
-- Phase 6 — Mission System + HUD
-- Phase 7 — Polish & MVP Ship
+- Placeholder art and procedural audio are used until bespoke assets land.
+- No persistent progression between sessions beyond local storage of settings.
+- AI navigation is simple; terrain collision and friendly units are not yet modelled.
+- Mobile/touch controls are not implemented.
 
-### Manual Test Checklist (Phase 0)
+## License
 
-1. `npm ci` installs dependencies without errors
-2. `npm run dev` starts Vite and serves index
-3. Canvas fills the window and shows the phase splash
-4. Resize window — canvas resizes without blurring
-5. `npm run build` completes without errors
-6. `npm run preview` serves built site correctly
-7. No console errors in latest Chrome/Edge/Firefox
-8. ESLint runs: `npm run lint`
-9. Prettier formats: `npm run format`
-10. Push to `main` triggers GitHub Pages deployment
-
-### Credits
-
-Created by the VineStrike team (original code and placeholder assets).
+- Code: MIT (`LICENSE`)
+- Placeholder assets: CC0 (`src/assets/LICENSE`)

--- a/index.html
+++ b/index.html
@@ -4,8 +4,8 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta name="color-scheme" content="light dark" />
-    <link rel="icon" href="./favicon.ico" />
-    <link rel="manifest" href="./manifest.webmanifest" />
+    <link rel="icon" href="/favicon.ico" />
+    <link rel="manifest" href="/manifest.webmanifest" />
     <title>VineStrike</title>
     <style>
       html,

--- a/package-lock.json
+++ b/package-lock.json
@@ -7,7 +7,7 @@
     "": {
       "name": "choppa",
       "version": "1.0.0",
-      "license": "ISC",
+      "license": "MIT",
       "devDependencies": {
         "@types/node": "^24.3.0",
         "@typescript-eslint/eslint-plugin": "^8.40.0",
@@ -19,6 +19,9 @@
         "prettier": "^3.6.2",
         "typescript": "^5.9.2",
         "vite": "^7.1.3"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@esbuild/aix-ppc64": {

--- a/src/game/components/AI.ts
+++ b/src/game/components/AI.ts
@@ -15,3 +15,24 @@ export interface SAM {
   missileSpeed: number; // tiles/sec initial
   lockProgress: number; // internal state 0..lockTime
 }
+
+export interface PatrolDrone {
+  axis: 'x' | 'y';
+  originX: number;
+  originY: number;
+  range: number;
+  speed: number;
+  direction: 1 | -1;
+  fireRange: number;
+  fireInterval: number;
+  cooldown: number;
+}
+
+export interface ChaserDrone {
+  speed: number;
+  acceleration: number;
+  fireRange: number;
+  fireInterval: number;
+  cooldown: number;
+  spread: number;
+}

--- a/src/game/systems/Damage.ts
+++ b/src/game/systems/Damage.ts
@@ -3,6 +3,7 @@ import type { ComponentStore } from '../../core/ecs/components';
 import type { Health } from '../components/Health';
 import type { Transform } from '../components/Transform';
 import type { Collider } from '../components/Collider';
+import type { Entity } from '../../core/ecs/entities';
 
 export interface PendingHit {
   x: number; // tile-space
@@ -13,6 +14,8 @@ export interface PendingHit {
 
 export class DamageSystem implements System {
   private hits: PendingHit[] = [];
+  private deadQueue: Entity[] = [];
+  private deadSet: Set<Entity> = new Set();
   constructor(
     private transforms: ComponentStore<Transform>,
     private colliders: ComponentStore<Collider>,
@@ -30,15 +33,36 @@ export class DamageSystem implements System {
       this.colliders.forEach((e, c) => {
         const t = this.transforms.get(e);
         const h = this.healths.get(e);
-        if (!t || !h) return;
+        if (!t || !h || h.current <= 0) return;
         const r = (c.radius || 0) + hit.radius;
         const dx = t.tx - hit.x;
         const dy = t.ty - hit.y;
         if (dx * dx + dy * dy <= r * r) {
           h.current = Math.max(0, h.current - hit.amount);
+          if (h.current <= 0) this.markDead(e);
         }
       });
     }
     this.hits.length = 0;
+  }
+
+  public reset(): void {
+    this.hits.length = 0;
+    this.deadQueue.length = 0;
+    this.deadSet.clear();
+  }
+
+  public consumeDeaths(): Entity[] {
+    if (this.deadQueue.length === 0) return [];
+    const out = this.deadQueue.slice();
+    this.deadQueue.length = 0;
+    this.deadSet.clear();
+    return out;
+  }
+
+  private markDead(entity: Entity): void {
+    if (this.deadSet.has(entity)) return;
+    this.deadSet.add(entity);
+    this.deadQueue.push(entity);
   }
 }

--- a/src/game/systems/EnemyBehavior.ts
+++ b/src/game/systems/EnemyBehavior.ts
@@ -1,0 +1,105 @@
+import type { System } from '../../core/ecs/systems';
+import type { ComponentStore } from '../../core/ecs/components';
+import type { Transform } from '../components/Transform';
+import type { Physics } from '../components/Physics';
+import type { PatrolDrone, ChaserDrone } from '../components/AI';
+import type { FireEvent } from './WeaponFire';
+import { RNG } from '../../core/util/rng';
+
+export class EnemyBehaviorSystem implements System {
+  constructor(
+    private transforms: ComponentStore<Transform>,
+    private physics: ComponentStore<Physics>,
+    private patrols: ComponentStore<PatrolDrone>,
+    private chasers: ComponentStore<ChaserDrone>,
+    private fireEvents: FireEvent[],
+    private rng: RNG,
+    private getPlayer: () => { x: number; y: number },
+  ) {}
+
+  update(dt: number): void {
+    const player = this.getPlayer();
+
+    this.patrols.forEach((entity, patrol) => {
+      const t = this.transforms.get(entity);
+      const phys = this.physics.get(entity);
+      if (!t || !phys) return;
+
+      // Patrol motion along a single axis
+      if (patrol.axis === 'x') {
+        if (t.tx > patrol.originX + patrol.range) patrol.direction = -1;
+        else if (t.tx < patrol.originX - patrol.range) patrol.direction = 1;
+        const targetV = patrol.direction * patrol.speed;
+        phys.ax = (targetV - phys.vx) * 3;
+        phys.ay = (0 - phys.vy) * 3;
+      } else {
+        if (t.ty > patrol.originY + patrol.range) patrol.direction = -1;
+        else if (t.ty < patrol.originY - patrol.range) patrol.direction = 1;
+        const targetV = patrol.direction * patrol.speed;
+        phys.ay = (targetV - phys.vy) * 3;
+        phys.ax = (0 - phys.vx) * 3;
+      }
+
+      // Firing logic
+      patrol.cooldown = Math.max(0, patrol.cooldown - dt);
+      const dx = player.x - t.tx;
+      const dy = player.y - t.ty;
+      const dist = Math.hypot(dx, dy);
+      if (dist <= patrol.fireRange && patrol.cooldown <= 0) {
+        patrol.cooldown = patrol.fireInterval;
+        const nx = dx / (dist || 1);
+        const ny = dy / (dist || 1);
+        this.fireEvents.push({
+          faction: 'enemy',
+          kind: 'cannon',
+          sx: t.tx,
+          sy: t.ty,
+          dx: nx,
+          dy: ny,
+          spread: 0.12,
+          speed: 18,
+          ttl: 0.9,
+          radius: 0.12,
+          damage: 4,
+        });
+      }
+    });
+
+    this.chasers.forEach((entity, chaser) => {
+      const t = this.transforms.get(entity);
+      const phys = this.physics.get(entity);
+      if (!t || !phys) return;
+
+      const dx = player.x - t.tx;
+      const dy = player.y - t.ty;
+      const dist = Math.hypot(dx, dy) || 1;
+      const desiredVx = (dx / dist) * chaser.speed;
+      const desiredVy = (dy / dist) * chaser.speed;
+      phys.ax = (desiredVx - phys.vx) * chaser.acceleration;
+      phys.ay = (desiredVy - phys.vy) * chaser.acceleration;
+
+      chaser.cooldown = Math.max(0, chaser.cooldown - dt);
+      if (dist <= chaser.fireRange && chaser.cooldown <= 0) {
+        chaser.cooldown = chaser.fireInterval;
+        const jitter = (this.rng.float01() - 0.5) * 2 * chaser.spread;
+        const cs = Math.cos(jitter);
+        const sn = Math.sin(jitter);
+        const dirX = (dx / dist) * cs - (dy / dist) * sn;
+        const dirY = (dx / dist) * sn + (dy / dist) * cs;
+        this.fireEvents.push({
+          faction: 'enemy',
+          kind: 'cannon',
+          sx: t.tx,
+          sy: t.ty,
+          dx: dirX,
+          dy: dirY,
+          spread: chaser.spread,
+          speed: 20,
+          ttl: 1.0,
+          radius: 0.1,
+          damage: 5,
+        });
+      }
+    });
+  }
+}

--- a/src/game/systems/Projectile.ts
+++ b/src/game/systems/Projectile.ts
@@ -24,6 +24,10 @@ export class ProjectilePool {
     this.items.push(p);
   }
 
+  public clear(): void {
+    this.items.length = 0;
+  }
+
   public update(
     dt: number,
     playerColliders: ComponentStore<Collider>,

--- a/src/main.ts
+++ b/src/main.ts
@@ -7,7 +7,7 @@ import { isoMapBounds, tileToIso, screenToApproxTile } from './render/iso/projec
 import { Camera2D } from './render/camera/camera';
 import { ParallaxSky } from './render/draw/parallax';
 import sampleMapJson from './world/tiles/sample_map.json';
-import { EntityRegistry } from './core/ecs/entities';
+import { EntityRegistry, type Entity } from './core/ecs/entities';
 import { ComponentStore } from './core/ecs/components';
 import type { Transform } from './game/components/Transform';
 import type { Physics } from './game/components/Physics';
@@ -24,9 +24,10 @@ import type { Ammo } from './game/components/Ammo';
 import type { WeaponHolder } from './game/components/Weapon';
 import { RNG } from './core/util/rng';
 import { ProjectilePool } from './game/systems/Projectile';
-import type { AAA, SAM } from './game/components/AI';
+import type { AAA, SAM, PatrolDrone, ChaserDrone } from './game/components/AI';
 import { AIControlSystem } from './game/systems/AIControl';
-import { drawAAATurret, drawSAM } from './render/sprites/targets';
+import { EnemyBehaviorSystem } from './game/systems/EnemyBehavior';
+import { drawAAATurret, drawSAM, drawPatrolDrone, drawChaserDrone } from './render/sprites/targets';
 import { Menu } from './ui/menus/menu';
 import { createUIStore, type UIStore } from './ui/menus/scenes';
 import { renderSettings, renderAchievements, renderAbout } from './ui/menus/renderers';
@@ -45,6 +46,32 @@ import { AudioBus } from './core/audio/audio';
 import { EngineSound, playCannon, playRocket, playMissile, playExplosion } from './core/audio/sfx';
 import { CameraShake } from './render/camera/shake';
 
+interface EnemyMeta {
+  kind: 'aaa' | 'sam' | 'patrol' | 'chaser';
+  score: number;
+  wave?: number;
+}
+
+interface Explosion {
+  tx: number;
+  ty: number;
+  age: number;
+  duration: number;
+}
+
+interface WaveState {
+  index: number;
+  countdown: number;
+  active: boolean;
+  timeInWave: number;
+  enemies: Set<Entity>;
+}
+
+interface PlayerState {
+  lives: number;
+  respawnTimer: number;
+  invulnerable: boolean;
+}
 const canvas = document.getElementById('game') as HTMLCanvasElement | null;
 if (!canvas) throw new Error('Canvas element with id "game" not found');
 const context = canvas.getContext('2d');
@@ -63,17 +90,14 @@ function resizeCanvasToDisplaySize(): void {
 window.addEventListener('resize', resizeCanvasToDisplaySize);
 resizeCanvasToDisplaySize();
 
-// Input
 const input = new InputManager();
 input.attach(window);
 
-// Debug overlay toggle with tilde
 const debug = new DebugOverlay();
 window.addEventListener('keydown', (e) => {
   if (e.key === '`' || e.key === '~') debug.toggle();
 });
 
-// UI store and menus
 const ui: UIStore = loadJson<UIStore>('vinestrike:ui', createUIStore());
 const titleMenu = new Menu([
   { id: 'start', label: 'Start Mission' },
@@ -83,21 +107,17 @@ const titleMenu = new Menu([
 ]);
 const bindings = loadBindings();
 
-// Simple counters for FPS & dt
-let fps = 0;
-let frames = 0;
-let accumulator = 0;
-
-// Phase 2: load a sample isometric map and set up camera
 const renderer = new IsoTilemapRenderer();
 const camera = new Camera2D({ deadzoneWidth: 160, deadzoneHeight: 120, lerp: 0.12 });
 const sky = new ParallaxSky();
 const fog = new FogOfWar(0.78);
-const bus = new AudioBus({ masterVolume: 0.9, musicVolume: 0.4, sfxVolume: 0.9 });
+const bus = new AudioBus({
+  masterVolume: ui.settings.masterVolume,
+  musicVolume: ui.settings.musicVolume,
+  sfxVolume: ui.settings.sfxVolume,
+});
 const engine = new EngineSound(bus);
 const shake = new CameraShake();
-
-// ECS world
 const entities = new EntityRegistry();
 const transforms = new ComponentStore<Transform>();
 const physics = new ComponentStore<Physics>();
@@ -107,36 +127,20 @@ const ammos = new ComponentStore<Ammo>();
 const weapons = new ComponentStore<WeaponHolder>();
 const aaas = new ComponentStore<AAA>();
 const sams = new ComponentStore<SAM>();
+const patrols = new ComponentStore<PatrolDrone>();
+const chasers = new ComponentStore<ChaserDrone>();
 const healths = new ComponentStore<Health>();
 const colliders = new ComponentStore<Collider>();
 
-// Systems
-const scheduler = new SystemScheduler();
-const rng = new RNG(1337);
-const projectilePool = new ProjectilePool();
-const fireEvents: FireEvent[] = [];
-const weaponFire = new WeaponFireSystem(transforms, physics, weapons, ammos, fireEvents, rng);
 let isoParams = { tileWidth: 64, tileHeight: 32 };
-let runtimeMap: ReturnType<typeof parseTiled> | null = null;
-const damage = new DamageSystem(transforms, colliders, healths);
-const mission = new MissionTracker(
-  loadMission(missionJson as MissionDef),
-  transforms,
-  colliders,
-  healths,
-  () => ({ tx: transforms.get(player)!.tx, ty: transforms.get(player)!.ty }),
-);
-
-runtimeMap = parseTiled(sampleMapJson as unknown);
+const runtimeMap = parseTiled(sampleMapJson as unknown);
 isoParams = { tileWidth: runtimeMap.tileWidth, tileHeight: runtimeMap.tileHeight };
-// Create a refuel pad near center
 const pad: RefuelPad = {
   tx: Math.floor(runtimeMap.width / 2) - 2,
   ty: Math.floor(runtimeMap.height / 2) + 1,
   radius: 1.2,
 };
 
-// Create player heli entity
 const player = entities.create();
 transforms.set(player, {
   tx: runtimeMap.width / 2,
@@ -166,7 +170,19 @@ weapons.set(player, { active: 'cannon', cooldownCannon: 0, cooldownRocket: 0, co
 healths.set(player, { current: 100, max: 100 });
 colliders.set(player, { radius: 0.4, team: 'player' });
 
-// Register systems
+const scheduler = new SystemScheduler();
+const rng = new RNG(1337);
+const projectilePool = new ProjectilePool();
+const fireEvents: FireEvent[] = [];
+const weaponFire = new WeaponFireSystem(transforms, physics, weapons, ammos, fireEvents, rng);
+const damage = new DamageSystem(transforms, colliders, healths);
+const missionDef = missionJson as MissionDef;
+let missionState = loadMission(missionDef);
+const mission = new MissionTracker(missionState, transforms, colliders, healths, () => ({
+  tx: transforms.get(player)!.tx,
+  ty: transforms.get(player)!.ty,
+}));
+
 scheduler.add(new MovementSystem(transforms, physics));
 scheduler.add(new RotorSpinSystem(sprites));
 scheduler.add(new FuelDrainSystem(fuels));
@@ -178,118 +194,458 @@ scheduler.add(
     y: transforms.get(player)!.ty,
   })),
 );
+scheduler.add(
+  new EnemyBehaviorSystem(transforms, physics, patrols, chasers, fireEvents, rng, () => ({
+    x: transforms.get(player)!.tx,
+    y: transforms.get(player)!.ty,
+  })),
+);
 
+const playerState: PlayerState = { lives: 3, respawnTimer: 0, invulnerable: false };
+const stats = { score: 0 };
+const explosions: Explosion[] = [];
+const enemyMeta = new Map<Entity, EnemyMeta>();
+const waveState: WaveState = {
+  index: 0,
+  countdown: 3,
+  active: false,
+  timeInWave: 0,
+  enemies: new Set<Entity>(),
+};
+const minimapEnemies: { tx: number; ty: number }[] = [];
+const waveSpawnPoints = [
+  { tx: 3, ty: 3 },
+  { tx: 12, ty: 4 },
+  { tx: 4, ty: 13 },
+  { tx: 12, ty: 12 },
+];
+
+let fps = 0;
+let frames = 0;
+let accumulator = 0;
+let lastStepDt = 1 / 60;
+let pauseLatch = false;
+let muteLatch = false;
+let audioMuted = false;
+function setAudioVolumes(): void {
+  bus.setMaster(audioMuted ? 0 : ui.settings.masterVolume);
+  bus.setMusic(ui.settings.musicVolume);
+  bus.setSfx(ui.settings.sfxVolume);
+}
+setAudioVolumes();
+
+function spawnExplosion(tx: number, ty: number): void {
+  explosions.push({ tx, ty, age: 0, duration: 0.6 });
+}
+
+function updateExplosions(dt: number): void {
+  for (let i = explosions.length - 1; i >= 0; i -= 1) {
+    const e = explosions[i]!;
+    e.age += dt;
+    if (e.age >= e.duration) explosions.splice(i, 1);
+  }
+}
+
+function destroyEntity(entity: Entity): void {
+  if (entity === player) return;
+  transforms.remove(entity);
+  physics.remove(entity);
+  fuels.remove(entity);
+  sprites.remove(entity);
+  ammos.remove(entity);
+  weapons.remove(entity);
+  aaas.remove(entity);
+  sams.remove(entity);
+  patrols.remove(entity);
+  chasers.remove(entity);
+  healths.remove(entity);
+  colliders.remove(entity);
+  enemyMeta.delete(entity);
+  waveState.enemies.delete(entity);
+  entities.destroy(entity);
+}
+
+function registerEnemy(entity: Entity, meta: EnemyMeta): void {
+  enemyMeta.set(entity, meta);
+  if (meta.wave !== undefined) waveState.enemies.add(entity);
+}
+
+function clearEnemies(): void {
+  const ids = Array.from(enemyMeta.keys());
+  for (let i = 0; i < ids.length; i += 1) destroyEntity(ids[i]!);
+  enemyMeta.clear();
+  waveState.enemies.clear();
+}
+
+function spawnMissionEnemies(): void {
+  if (!mission.state.def.enemySpawns) return;
+  for (let i = 0; i < mission.state.def.enemySpawns.length; i += 1) {
+    const spawn = mission.state.def.enemySpawns[i]!;
+    const entity = entities.create();
+    transforms.set(entity, { tx: spawn.at.tx, ty: spawn.at.ty, rot: 0 });
+    healths.set(entity, { current: 30, max: 30 });
+    colliders.set(entity, { radius: 0.5, team: 'enemy' });
+    if (spawn.type === 'AAA') {
+      aaas.set(entity, {
+        range: 8,
+        cooldown: 0,
+        fireInterval: 0.6,
+        projectileSpeed: 12,
+        spread: 0.06,
+      });
+      registerEnemy(entity, { kind: 'aaa', score: 150 });
+    } else {
+      sams.set(entity, {
+        range: 12,
+        lockTime: 0.8,
+        cooldown: 0,
+        fireInterval: 2.5,
+        turnRate: Math.PI * 0.7,
+        missileSpeed: 6,
+        lockProgress: 0,
+      });
+      registerEnemy(entity, { kind: 'sam', score: 200 });
+    }
+  }
+}
+
+function spawnPatrolEnemy(point: { tx: number; ty: number }, wave: number, axis: 'x' | 'y'): void {
+  const entity = entities.create();
+  transforms.set(entity, { tx: point.tx, ty: point.ty, rot: 0 });
+  physics.set(entity, {
+    vx: 0,
+    vy: 0,
+    ax: 0,
+    ay: 0,
+    drag: 0.9,
+    maxSpeed: 2.2 + wave * 0.1,
+    turnRate: Math.PI,
+  });
+  healths.set(entity, { current: 22 + wave * 3, max: 22 + wave * 3 });
+  colliders.set(entity, { radius: 0.4, team: 'enemy' });
+  patrols.set(entity, {
+    axis,
+    originX: point.tx,
+    originY: point.ty,
+    range: 2.5 + Math.min(4, wave * 0.6),
+    speed: 1.8 + wave * 0.2,
+    direction: rng.float01() > 0.5 ? 1 : -1,
+    fireRange: 6.5,
+    fireInterval: Math.max(0.9, 1.4 - wave * 0.1),
+    cooldown: 0,
+  });
+  registerEnemy(entity, { kind: 'patrol', score: 125 + wave * 15, wave });
+}
+
+function spawnChaserEnemy(point: { tx: number; ty: number }, wave: number): void {
+  const entity = entities.create();
+  transforms.set(entity, { tx: point.tx, ty: point.ty, rot: 0 });
+  physics.set(entity, {
+    vx: 0,
+    vy: 0,
+    ax: 0,
+    ay: 0,
+    drag: 0.7,
+    maxSpeed: 3.2 + wave * 0.25,
+    turnRate: Math.PI * 1.4,
+  });
+  healths.set(entity, { current: 26 + wave * 4, max: 26 + wave * 4 });
+  colliders.set(entity, { radius: 0.35, team: 'enemy' });
+  chasers.set(entity, {
+    speed: 2.6 + wave * 0.25,
+    acceleration: 3.2,
+    fireRange: 6,
+    fireInterval: Math.max(0.8, 1.3 - wave * 0.1),
+    cooldown: 0,
+    spread: 0.18,
+  });
+  registerEnemy(entity, { kind: 'chaser', score: 220 + wave * 20, wave });
+}
+
+function spawnWave(index: number): void {
+  waveState.enemies.clear();
+  const patrolCount = Math.min(waveSpawnPoints.length, 2 + index);
+  const chaserCount = Math.min(waveSpawnPoints.length, Math.max(0, Math.floor(index / 2)));
+  for (let i = 0; i < patrolCount; i += 1) {
+    const point = waveSpawnPoints[i % waveSpawnPoints.length]!;
+    const axis: 'x' | 'y' = i % 2 === 0 ? 'x' : 'y';
+    spawnPatrolEnemy(point, index, axis);
+  }
+  for (let i = 0; i < chaserCount; i += 1) {
+    const point = waveSpawnPoints[(i + patrolCount) % waveSpawnPoints.length]!;
+    spawnChaserEnemy(point, index);
+  }
+}
+
+function resetPlayer(): void {
+  const t = transforms.get(player);
+  const ph = physics.get(player);
+  const fuel = fuels.get(player);
+  const ammo = ammos.get(player);
+  const health = healths.get(player);
+  if (t && ph && fuel && ammo && health) {
+    t.tx = mission.state.def.startPos.tx;
+    t.ty = mission.state.def.startPos.ty;
+    t.rot = 0;
+    ph.vx = 0;
+    ph.vy = 0;
+    ph.ax = 0;
+    ph.ay = 0;
+    fuel.current = fuel.max;
+    ammo.cannon = ammo.cannonMax;
+    ammo.rockets = ammo.rocketsMax;
+    ammo.missiles = ammo.missilesMax;
+    health.current = health.max;
+    colliders.set(player, { radius: 0.4, team: 'player' });
+  }
+  playerState.respawnTimer = 0;
+  playerState.invulnerable = false;
+  engine.start();
+  engine.setIntensity(0);
+}
+
+function resetGame(): void {
+  clearEnemies();
+  projectilePool.clear();
+  damage.reset();
+  explosions.length = 0;
+  stats.score = 0;
+  waveState.index = 0;
+  waveState.countdown = 3.5;
+  waveState.active = false;
+  waveState.timeInWave = 0;
+  missionState = loadMission(missionDef);
+  mission.state = missionState;
+  spawnMissionEnemies();
+  playerState.lives = 3;
+  resetPlayer();
+  ui.state = 'in-game';
+  setAudioVolumes();
+}
+
+function handlePlayerDeath(): void {
+  if (playerState.invulnerable) return;
+  const t = transforms.get(player);
+  if (t) spawnExplosion(t.tx, t.ty);
+  playExplosion(bus);
+  colliders.remove(player);
+  const ph = physics.get(player);
+  if (ph) {
+    ph.vx = 0;
+    ph.vy = 0;
+    ph.ax = 0;
+    ph.ay = 0;
+  }
+  playerState.lives -= 1;
+  playerState.invulnerable = true;
+  playerState.respawnTimer = 2.5;
+  if (playerState.lives <= 0) {
+    ui.state = 'game-over';
+    waveState.active = false;
+    engine.stop();
+  }
+}
+
+function tryRespawn(dt: number): void {
+  if (!playerState.invulnerable || ui.state === 'game-over') return;
+  playerState.respawnTimer -= dt;
+  if (playerState.respawnTimer <= 0 && playerState.lives > 0) {
+    resetPlayer();
+  }
+}
+
+function handleDeaths(): void {
+  const deaths = damage.consumeDeaths();
+  for (let i = 0; i < deaths.length; i += 1) {
+    const entity = deaths[i]!;
+    if (entity === player) {
+      handlePlayerDeath();
+      continue;
+    }
+    const meta = enemyMeta.get(entity);
+    if (meta) {
+      const t = transforms.get(entity);
+      if (t) spawnExplosion(t.tx, t.ty);
+      playExplosion(bus);
+      stats.score += meta.score;
+      destroyEntity(entity);
+      continue;
+    }
+    destroyEntity(entity);
+  }
+}
+
+function updateWave(dt: number): void {
+  if (ui.state !== 'in-game') return;
+  if (waveState.active) {
+    waveState.timeInWave += dt;
+    if (waveState.enemies.size === 0) {
+      waveState.active = false;
+      waveState.countdown = Math.max(3, 5 - waveState.index * 0.2);
+    }
+  } else {
+    waveState.countdown -= dt;
+    if (waveState.countdown <= 0) {
+      waveState.index += 1;
+      spawnWave(waveState.index);
+      waveState.active = true;
+      waveState.timeInWave = 0;
+    }
+  }
+}
+
+spawnMissionEnemies();
 const loop = new GameLoop({
   update: (dt) => {
-    // Consume input snapshot
+    lastStepDt = dt;
     const snap = input.readSnapshot();
 
-    // Global UI transitions
-    if (isDown(snap, bindings, 'pause')) {
+    const pauseDown = isDown(snap, bindings, 'pause');
+    if (pauseDown && !pauseLatch) {
       if (ui.state === 'in-game') ui.state = 'paused';
       else if (ui.state === 'paused') ui.state = 'in-game';
-      else ui.state = 'title';
-      saveJson('vinestrike:ui', ui);
+      else if (ui.state === 'title') ui.state = 'in-game';
     }
+    pauseLatch = pauseDown;
 
-    // Title and menus
+    const muteDown = snap.keys['m'] || snap.keys['M'];
+    if (muteDown && !muteLatch) {
+      audioMuted = !audioMuted;
+      setAudioVolumes();
+    }
+    muteLatch = muteDown;
+
     if (ui.state === 'title') {
       const action = titleMenu.update(snap);
-      if (action === 'start') ui.state = 'in-game';
-      else if (action === 'settings') ui.state = 'settings';
+      if (action === 'start') {
+        resetGame();
+      } else if (action === 'settings') ui.state = 'settings';
       else if (action === 'achievements') ui.state = 'achievements';
       else if (action === 'about') ui.state = 'about';
       if (action) saveJson('vinestrike:ui', ui);
-      // Skip game simulation while in title
-      return;
-    } else if (
-      ui.state === 'settings' ||
-      ui.state === 'achievements' ||
-      ui.state === 'about' ||
-      ui.state === 'paused'
-    ) {
-      // No simulation when in menu overlays (MVP)
       return;
     }
 
-    // In-game simulation below
+    if (ui.state === 'settings') {
+      if (snap.keys['Escape']) ui.state = 'title';
+      return;
+    }
+
+    if (ui.state === 'achievements') {
+      if (snap.keys['Escape']) ui.state = 'title';
+      return;
+    }
+
+    if (ui.state === 'about') {
+      if (snap.keys['Escape']) ui.state = 'title';
+      return;
+    }
+
+    if (ui.state === 'paused') {
+      if (snap.keys['Escape']) ui.state = 'in-game';
+      return;
+    }
+
+    if (ui.state === 'game-over') {
+      if (snap.keys['Enter'] || snap.keys[' '] || snap.keys['r'] || snap.keys['R']) {
+        resetGame();
+      }
+      if (snap.keys['Escape']) ui.state = 'title';
+      return;
+    }
+
+    if (ui.state === 'win') {
+      if (snap.keys['Enter'] || snap.keys[' ']) resetGame();
+      if (snap.keys['Escape']) ui.state = 'title';
+      return;
+    }
+
+    tryRespawn(dt);
+
+    const playerTransform = transforms.get(player)!;
     const ph = physics.get(player)!;
     let dx = 0;
     let dy = 0;
-    if (isDown(snap, bindings, 'moveUp')) dy -= 1;
-    if (isDown(snap, bindings, 'moveDown')) dy += 1;
-    if (isDown(snap, bindings, 'moveLeft')) dx -= 1;
-    if (isDown(snap, bindings, 'moveRight')) dx += 1;
+    if (!playerState.invulnerable) {
+      if (isDown(snap, bindings, 'moveUp')) dy -= 1;
+      if (isDown(snap, bindings, 'moveDown')) dy += 1;
+      if (isDown(snap, bindings, 'moveLeft')) dx -= 1;
+      if (isDown(snap, bindings, 'moveRight')) dx += 1;
+    }
     if (dx !== 0 || dy !== 0) {
       const len = Math.hypot(dx, dy) || 1;
       dx /= len;
       dy /= len;
     }
-    const accel = 12; // tiles/sec^2
+    const accel = 12;
     ph.ax = dx * accel;
     ph.ay = dy * accel;
-    // Engine audio intensity by speed
+
     const speed = Math.min(1, Math.hypot(ph.vx, ph.vy) / (physics.get(player)!.maxSpeed || 1));
     engine.start();
     engine.setIntensity(speed);
 
-    // Set weapon input (use mouse position to aim in screen pixels → convert to tile space approx)
     const w = context.canvas.width;
     const h = context.canvas.height;
-    const aimTile = screenToApproxTile(
-      snap.mouseX,
-      snap.mouseY,
-      w,
-      h,
-      camera.x,
-      camera.y,
-      isoParams,
-    );
+    let aimTile = screenToApproxTile(snap.mouseX, snap.mouseY, w, h, camera.x, camera.y, isoParams);
+    const aimDx = aimTile.x - playerTransform.tx;
+    const aimDy = aimTile.y - playerTransform.ty;
+    if (!Number.isFinite(aimDx) || !Number.isFinite(aimDy) || Math.hypot(aimDx, aimDy) < 0.3) {
+      aimTile = {
+        x: playerTransform.tx + Math.cos(playerTransform.rot),
+        y: playerTransform.ty + Math.sin(playerTransform.rot),
+      };
+    }
     weaponFire.setInput(snap, aimTile.x, aimTile.y);
 
-    // Run systems (deterministic order)
     scheduler.update(dt);
 
-    // Consume fire events to spawn projectiles
+    const margin = 1.2;
+    const maxX = runtimeMap.width - 1 - margin;
+    const maxY = runtimeMap.height - 1 - margin;
+    playerTransform.tx = Math.max(margin, Math.min(maxX, playerTransform.tx));
+    playerTransform.ty = Math.max(margin, Math.min(maxY, playerTransform.ty));
+
     for (let i = 0; i < fireEvents.length; i += 1) {
       const ev = fireEvents[i]!;
       if (ev.kind === 'cannon') {
         playCannon(bus);
+        const speedC = ev.speed ?? 18;
         projectilePool.spawn({
           kind: 'cannon',
-          faction: ev.faction || 'player',
+          faction: ev.faction,
           x: ev.sx,
           y: ev.sy,
-          vx: ev.dx * 18,
-          vy: ev.dy * 18,
-          ttl: 0.08,
-          radius: 0.05,
-          damage: { amount: 3 },
+          vx: ev.dx * speedC,
+          vy: ev.dy * speedC,
+          ttl: ev.ttl ?? 0.8,
+          radius: ev.radius ?? 0.08,
+          damage: { amount: ev.damage ?? 4 },
         });
       } else if (ev.kind === 'rocket') {
         playRocket(bus);
         projectilePool.spawn({
           kind: 'rocket',
-          faction: ev.faction || 'player',
+          faction: ev.faction,
           x: ev.x,
           y: ev.y,
           vx: ev.vx,
           vy: ev.vy,
-          ttl: 4,
-          radius: 0.18,
+          ttl: ev.ttl ?? 4,
+          radius: ev.radius ?? 0.18,
           damage: { amount: 12, radius: 0.6 },
         });
       } else if (ev.kind === 'missile') {
         playMissile(bus);
         projectilePool.spawn({
           kind: 'missile',
-          faction: ev.faction || 'player',
+          faction: ev.faction,
           x: ev.x,
           y: ev.y,
           vx: ev.vx,
           vy: ev.vy,
-          ttl: 6,
-          radius: 0.18,
+          ttl: ev.ttl ?? 6,
+          radius: ev.radius ?? 0.18,
           seek: { targetX: ev.targetX, targetY: ev.targetY, turnRate: Math.PI * 0.8 },
           damage: { amount: 18, radius: 0.9 },
         });
@@ -297,22 +653,24 @@ const loop = new GameLoop({
     }
     fireEvents.length = 0;
 
-    // Update projectiles
-    projectilePool.update(
-      dt,
-      colliders /* player */,
-      colliders /* enemy (placeholder) */,
-      transforms,
-      (hit) => {
-        damage.queue(hit);
-        playExplosion(bus);
-        if (ui.settings.screenShake) shake.trigger(8, 0.25);
-      },
-    );
-    damage.update();
-    mission.update();
+    projectilePool.update(dt, colliders, colliders, transforms, (hit) => {
+      damage.queue(hit);
+      playExplosion(bus);
+      if (ui.settings.screenShake) shake.trigger(8, 0.25);
+    });
 
-    // Update FPS measurement
+    damage.update();
+    handleDeaths();
+
+    mission.update();
+    if (mission.state.complete && ui.state === 'in-game') {
+      ui.state = 'win';
+      saveJson('vinestrike:progress', { lastWin: Date.now(), mission: mission.state.def.id });
+    }
+
+    updateWave(dt);
+    updateExplosions(dt);
+
     accumulator += dt;
     frames += 1;
     if (accumulator >= 0.5) {
@@ -326,12 +684,10 @@ const loop = new GameLoop({
     const w = canvas.width;
     const h = canvas.height;
     fog.resize(w, h);
-    // Parallax sky
     sky.render(context, camera.x, camera.y);
 
-    // Menus
     if (ui.state === 'title') {
-      titleMenu.render(context, 'VineStrike', 'An original isometric helicopter action prototype');
+      titleMenu.render(context, 'VineStrike', 'Isometric helicopter action prototype');
       return;
     }
     if (ui.state === 'settings') {
@@ -346,142 +702,154 @@ const loop = new GameLoop({
       renderAbout(context);
       return;
     }
-    if (ui.state === 'paused') {
-      // Draw game underlay then a pause overlay
+
+    const playerT = transforms.get(player)!;
+    const bounds = isoMapBounds(runtimeMap.width, runtimeMap.height, isoParams);
+    camera.bounds = bounds;
+    const targetIso = tileToIso(playerT.tx, playerT.ty, isoParams);
+    camera.follow(targetIso.x, targetIso.y, w, h);
+
+    const originX = Math.floor(w / 2 - camera.x);
+    const originY = Math.floor(h / 2 - camera.y);
+    const shakeOffset = shake.offset(1 / 60);
+    renderer.draw(context, runtimeMap, isoParams, originX + shakeOffset.x, originY + shakeOffset.y);
+
+    aaas.forEach((entity, _a) => {
+      const t = transforms.get(entity);
+      if (t) drawAAATurret(context, isoParams, originX, originY, t.tx, t.ty);
+    });
+    sams.forEach((entity, _s) => {
+      const t = transforms.get(entity);
+      if (t) drawSAM(context, isoParams, originX, originY, t.tx, t.ty);
+    });
+    patrols.forEach((entity, _p) => {
+      const t = transforms.get(entity);
+      if (t) drawPatrolDrone(context, isoParams, originX, originY, t.tx, t.ty);
+    });
+    chasers.forEach((entity, _c) => {
+      const t = transforms.get(entity);
+      if (t) drawChaserDrone(context, isoParams, originX, originY, t.tx, t.ty);
+    });
+
+    projectilePool.draw(
+      context,
+      originX + shakeOffset.x,
+      originY + shakeOffset.y,
+      isoParams.tileWidth,
+      isoParams.tileHeight,
+    );
+
+    for (let i = 0; i < explosions.length; i += 1) {
+      const e = explosions[i]!;
+      const iso = tileToIso(e.tx, e.ty, isoParams);
+      const drawX = originX + iso.x + shakeOffset.x;
+      const drawY = originY + iso.y + shakeOffset.y - 10;
+      const alpha = 1 - e.age / e.duration;
+      context.save();
+      context.globalAlpha = Math.max(0, alpha);
+      context.fillStyle = '#ffb347';
+      context.beginPath();
+      context.arc(drawX, drawY, 16 * alpha, 0, Math.PI * 2);
+      context.fill();
+      context.restore();
     }
 
-    if (runtimeMap) {
-      // Camera follow and clamp to iso map bounds
-      const bounds = isoMapBounds(runtimeMap.width, runtimeMap.height, isoParams);
-      camera.bounds = bounds;
-      const playerT = transforms.get(player)!;
-      const targetIso = tileToIso(playerT.tx, playerT.ty, isoParams);
-      camera.follow(targetIso.x, targetIso.y, w, h);
+    drawPad(context, isoParams, originX + shakeOffset.x, originY + shakeOffset.y, pad.tx, pad.ty);
 
-      // Map origin is camera-centered
-      const originX = Math.floor(w / 2 - camera.x);
-      const originY = Math.floor(h / 2 - camera.y);
-      const shakeOffset = shake.offset(1 / 60);
-      renderer.draw(
-        context,
-        runtimeMap,
-        isoParams,
-        originX + shakeOffset.x,
-        originY + shakeOffset.y,
-      );
-      // Spawn enemies from mission definition (once)
-      if (aaas.get(1) === undefined && (mission as any).state?.def?.enemySpawns) {
-        const spawns = (mission as any).state.def.enemySpawns as Array<{
-          type: 'AAA' | 'SAM';
-          at: { tx: number; ty: number };
-        }>;
-        for (let i = 0; i < spawns.length; i += 1) {
-          const s = spawns[i]!;
-          const e = entities.create();
-          transforms.set(e, { tx: s.at.tx, ty: s.at.ty, rot: 0 });
-          healths.set(e, { current: 30, max: 30 });
-          colliders.set(e, { radius: 0.5, team: 'enemy' });
-          if (s.type === 'AAA') {
-            aaas.set(e, {
-              range: 8,
-              cooldown: 0,
-              fireInterval: 0.6,
-              projectileSpeed: 12,
-              spread: 0.06,
-            });
-          } else {
-            sams.set(e, {
-              range: 12,
-              lockTime: 0.8,
-              cooldown: 0,
-              fireInterval: 2.5,
-              turnRate: Math.PI * 0.7,
-              missileSpeed: 6,
-              lockProgress: 0,
-            });
-          }
-        }
+    drawHeli(context, {
+      tx: playerT.tx,
+      ty: playerT.ty,
+      rot: playerT.rot,
+      rotorPhase: sprites.get(player)!.rotor,
+      color: sprites.get(player)!.color,
+      iso: isoParams,
+      originX: originX + shakeOffset.x,
+      originY: originY + shakeOffset.y,
+    });
+
+    minimapEnemies.length = 0;
+    colliders.forEach((entity, col) => {
+      if (col.team === 'enemy') {
+        const t = transforms.get(entity);
+        if (t) minimapEnemies.push({ tx: t.tx, ty: t.ty });
       }
+    });
 
-      // Draw enemy emplacements
-      aaas.forEach((e, _a) => {
-        const t = transforms.get(e)!;
-        drawAAATurret(context, isoParams, originX, originY, t.tx, t.ty);
-      });
-      sams.forEach((e, _s) => {
-        const t = transforms.get(e)!;
-        drawSAM(context, isoParams, originX, originY, t.tx, t.ty);
-      });
-      // Draw projectiles
-      projectilePool.draw(
-        context,
-        originX + shakeOffset.x,
-        originY + shakeOffset.y,
-        isoParams.tileWidth,
-        isoParams.tileHeight,
-      );
+    if (ui.settings.fogOfWar) {
+      const playerIso = tileToIso(playerT.tx, playerT.ty, isoParams);
+      const holeX = Math.floor(w / 2 + (playerIso.x - camera.x));
+      const holeY = Math.floor(h / 2 + (playerIso.y - camera.y));
+      fog.render(context, [
+        { x: holeX, y: holeY, radius: Math.max(120, Math.min(w, h) * 0.22), softness: 0.5 },
+      ]);
+    }
 
-      // Draw refuel pad
-      drawPad(context, isoParams, originX + shakeOffset.x, originY + shakeOffset.y, pad.tx, pad.ty);
-
-      // Draw player heli
-      const sprite = sprites.get(player)!;
-      drawHeli(context, {
-        tx: playerT.tx,
-        ty: playerT.ty,
-        rot: playerT.rot,
-        rotorPhase: sprite.rotor,
-        color: sprite.color,
-        iso: isoParams,
-        originX: originX + shakeOffset.x,
-        originY: originY + shakeOffset.y,
-      });
-
-      // HUD (minimap toggle)
-      drawHUD(
-        context,
-        {
-          fuel01: fuels.get(player)!.current / fuels.get(player)!.max,
-          armor01: healths.get(player)!.current / healths.get(player)!.max,
-          ammo: {
-            cannon: ammos.get(player)!.cannon,
-            rockets: ammos.get(player)!.rockets,
-            missiles: ammos.get(player)!.missiles,
-          },
-          activeWeapon: weapons.get(player)!.active,
+    drawHUD(
+      context,
+      {
+        fuel01: fuels.get(player)!.current / fuels.get(player)!.max,
+        armor01: healths.get(player)!.current / healths.get(player)!.max,
+        ammo: {
+          cannon: ammos.get(player)!.cannon,
+          rockets: ammos.get(player)!.rockets,
+          missiles: ammos.get(player)!.missiles,
         },
-        mission.state.objectives.map((o) => `${o.complete ? '[x]' : '[ ]'} ${o.name}`),
-        null,
-        {
-          mapW: runtimeMap.width,
-          mapH: runtimeMap.height,
-          player: { tx: playerT.tx, ty: playerT.ty },
-          enemies: [],
-        },
-        isoParams,
-      );
+        activeWeapon: weapons.get(player)!.active,
+        lives: Math.max(0, playerState.lives),
+        score: stats.score,
+        wave: waveState.active ? waveState.index : Math.max(1, waveState.index + 1),
+        enemiesRemaining: waveState.enemies.size,
+        nextWaveIn: waveState.active ? null : waveState.countdown,
+      },
+      mission.state.objectives.map((o) => `${o.complete ? '[x]' : '[ ]'} ${o.name}`),
+      null,
+      {
+        mapW: runtimeMap.width,
+        mapH: runtimeMap.height,
+        player: { tx: playerT.tx, ty: playerT.ty },
+        enemies: minimapEnemies,
+      },
+      isoParams,
+    );
 
-      // Fog of war overlay (player-centric circle). In future: add holes for allies/objectives.
-      if (ui.settings.fogOfWar) {
-        const playerIso = tileToIso(playerT.tx, playerT.ty, isoParams);
-        const holeX = Math.floor(w / 2 + (playerIso.x - camera.x));
-        const holeY = Math.floor(h / 2 + (playerIso.y - camera.y));
-        fog.render(context, [
-          { x: holeX, y: holeY, radius: Math.max(120, Math.min(w, h) * 0.22), softness: 0.5 },
-        ]);
-      }
+    if (playerState.invulnerable && ui.state === 'in-game') {
+      context.save();
+      context.fillStyle = 'rgba(0, 0, 0, 0.35)';
+      context.fillRect(0, 0, w, h);
+      context.fillStyle = '#ffd166';
+      context.font = 'bold 18px system-ui, sans-serif';
+      context.textAlign = 'center';
+      context.fillText('Respawning...', w / 2, h / 2);
+      context.restore();
+    }
 
-      // Win overlay
-      if (mission.state.complete) {
-        ui.state = 'win';
-        saveJson('vinestrike:progress', { lastWin: Date.now(), mission: mission.state.def.id });
-      }
-    } else {
-      // Loading state (should not occur with static import)
+    if (ui.state === 'paused') {
+      context.save();
+      context.fillStyle = 'rgba(0, 0, 0, 0.55)';
+      context.fillRect(0, 0, w, h);
+      context.fillStyle = '#92ffa6';
+      context.font = 'bold 28px system-ui, sans-serif';
+      context.textAlign = 'center';
+      context.fillText('Paused', w / 2, h / 2);
       context.fillStyle = '#c8d7e1';
       context.font = '14px system-ui, sans-serif';
+      context.fillText('Press Esc to resume', w / 2, h / 2 + 24);
+      context.restore();
+    }
+
+    if (ui.state === 'game-over') {
+      context.save();
+      context.fillStyle = 'rgba(0, 0, 0, 0.7)';
+      context.fillRect(0, 0, w, h);
+      context.fillStyle = '#ef476f';
+      context.font = 'bold 28px system-ui, sans-serif';
       context.textAlign = 'center';
-      context.fillText('Loading isometric map...', w / 2, h / 2);
+      context.fillText('Mission Failed', w / 2, h / 2);
+      context.fillStyle = '#c8d7e1';
+      context.font = '14px system-ui, sans-serif';
+      context.fillText('Press Enter to restart or Esc for title', w / 2, h / 2 + 26);
+      context.restore();
+      return;
     }
 
     if (ui.state === 'win') {
@@ -494,12 +862,12 @@ const loop = new GameLoop({
       context.fillText('Mission Complete', w / 2, h / 2 - 8);
       context.fillStyle = '#c8d7e1';
       context.font = '14px system-ui, sans-serif';
-      context.fillText('Press Esc to return to Title', w / 2, h / 2 + 16);
+      context.fillText('Press Enter to restart or Esc for title', w / 2, h / 2 + 16);
       context.restore();
       return;
     }
 
-    debug.render(context, { fps, dt: 1 / 60, entities: 0 });
+    debug.render(context, { fps, dt: lastStepDt, entities: enemyMeta.size + 1 });
   },
 });
 

--- a/src/render/sprites/targets.ts
+++ b/src/render/sprites/targets.ts
@@ -57,3 +57,57 @@ export function drawSAM(
   ctx.fillRect(-2, -10, 4, 8);
   ctx.restore();
 }
+
+export function drawPatrolDrone(
+  ctx: CanvasRenderingContext2D,
+  iso: IsoParams,
+  originX: number,
+  originY: number,
+  tx: number,
+  ty: number,
+): void {
+  const halfW = iso.tileWidth / 2;
+  const halfH = iso.tileHeight / 2;
+  const ix = (tx - ty) * halfW;
+  const iy = (tx + ty) * halfH;
+  ctx.save();
+  ctx.translate(originX + ix, originY + iy);
+  ctx.fillStyle = '#3e4c65';
+  ctx.strokeStyle = '#1d2533';
+  ctx.lineWidth = 2;
+  ctx.beginPath();
+  ctx.roundRect(-5, -4, 10, 8, 2);
+  ctx.fill();
+  ctx.stroke();
+  ctx.fillStyle = '#9fb3c8';
+  ctx.fillRect(-2, -8, 4, 4);
+  ctx.restore();
+}
+
+export function drawChaserDrone(
+  ctx: CanvasRenderingContext2D,
+  iso: IsoParams,
+  originX: number,
+  originY: number,
+  tx: number,
+  ty: number,
+): void {
+  const halfW = iso.tileWidth / 2;
+  const halfH = iso.tileHeight / 2;
+  const ix = (tx - ty) * halfW;
+  const iy = (tx + ty) * halfH;
+  ctx.save();
+  ctx.translate(originX + ix, originY + iy);
+  ctx.fillStyle = '#5a2f43';
+  ctx.strokeStyle = '#2a0f1c';
+  ctx.lineWidth = 2;
+  ctx.beginPath();
+  ctx.roundRect(-5, -5, 10, 10, 3);
+  ctx.fill();
+  ctx.stroke();
+  ctx.fillStyle = '#ffd166';
+  ctx.beginPath();
+  ctx.arc(0, -2, 2.5, 0, Math.PI * 2);
+  ctx.fill();
+  ctx.restore();
+}

--- a/src/ui/hud/hud.ts
+++ b/src/ui/hud/hud.ts
@@ -5,6 +5,11 @@ export interface BarsData {
   armor01: number;
   ammo: { cannon: number; rockets: number; missiles: number };
   activeWeapon: string;
+  lives: number;
+  score: number;
+  wave: number;
+  enemiesRemaining: number;
+  nextWaveIn: number | null;
 }
 
 export function drawHUD(
@@ -35,6 +40,9 @@ export function drawHUD(
     x0,
     y0 - 44,
   );
+  ctx.fillStyle = '#c8d7e1';
+  ctx.font = '12px system-ui, sans-serif';
+  ctx.fillText(`Lives: ${bars.lives}`, x0, y0 - 60);
 
   // Objective list top-left
   ctx.textAlign = 'left';
@@ -85,6 +93,20 @@ export function drawHUD(
   const ppx = mmX + (minimap.player.tx / minimap.mapW) * mmW;
   const ppy = mmY + (minimap.player.ty / minimap.mapH) * mmH;
   ctx.fillRect(ppx - 2, ppy - 2, 4, 4);
+
+  // Score & wave stats near minimap
+  ctx.textAlign = 'right';
+  ctx.fillStyle = '#c8d7e1';
+  ctx.font = '14px system-ui, sans-serif';
+  ctx.fillText(`Score: ${Math.floor(bars.score)}`, mmX + mmW, mmY + mmH + 20);
+  ctx.fillText(
+    `Wave: ${bars.wave}  Remaining: ${bars.enemiesRemaining}`,
+    mmX + mmW,
+    mmY + mmH + 40,
+  );
+  if (bars.nextWaveIn !== null) {
+    ctx.fillText(`Next wave in: ${bars.nextWaveIn.toFixed(1)}s`, mmX + mmW, mmY + mmH + 60);
+  }
 
   // Compass top-center
   if (compassDir) {

--- a/src/ui/menus/scenes.ts
+++ b/src/ui/menus/scenes.ts
@@ -5,7 +5,8 @@ export type UIState =
   | 'about'
   | 'in-game'
   | 'paused'
-  | 'win';
+  | 'win'
+  | 'game-over';
 
 export interface SettingsState {
   masterVolume: number;

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -4,7 +4,7 @@ export default defineConfig({
   // Use repo name for GitHub Pages project site
   base: '/Choppa/',
   server: {
-    open: true,
+    open: false,
   },
   build: {
     sourcemap: true,


### PR DESCRIPTION
## Summary
- implement patrol and chaser enemies, wave controller, player lives, and richer HUD/menus for the MVP
- refactor the main loop for clean pauses, respawns, explosions, and mission-aware enemy spawns with audio mute toggle
- expand weapon controls, add enemy behaviour system, disable dev auto-open, and refresh the README quickstart
- fix manifest and favicon link paths so GitHub Pages and the local dev server resolve the assets without 404s

## Testing
- npm run lint
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68c9ae9d0c08832780a8bb9aa24bdeb3