### PR TITLE
Fix asset paths for GitHub Pages deployment

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,8 +4,8 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta name="color-scheme" content="light dark" />
-    <link rel="icon" href="/favicon.ico" />
-    <link rel="manifest" href="/manifest.webmanifest" />
+    <link rel="icon" href="favicon.ico" />
+    <link rel="manifest" href="manifest.webmanifest" />
     <title>VineStrike</title>
     <style>
       html,
@@ -46,6 +46,6 @@
       <canvas id="game"></canvas>
       <noscript>VineStrike requires JavaScript.</noscript>
     </div>
-    <script type="module" src="/src/main.ts"></script>
+    <script type="module" src="src/main.ts"></script>
   </body>
 </html>


### PR DESCRIPTION
## Summary
- make the favicon and web manifest references relative so GitHub Pages serves them from the repository subpath
- load the Vite entry module with a relative path to avoid 404s when the site is hosted from `/Choppa`

## Testing
- npm run build
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68caeeb52308832790557075e056a670