### PR TITLE
Remove stray identifier causing render failure

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -1028,8 +1028,6 @@ const loop = new GameLoop({
         collectorIso,
       });
     });
-main
-
     aaas.forEach((entity, _a) => {
       const t = transforms.get(entity);
       if (t) drawAAATurret(context, isoParams, originWithShakeX, originWithShakeY, t.tx, t.ty);


### PR DESCRIPTION
## Summary
- remove an unintended `main` identifier left in the render loop that crashed the game

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68cd6181f7108327966388681cf65b9c