### PR TITLE
Retheme missiles and hellfires

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,9 +27,9 @@ production.
 ## Controls
 
 - **WASD / Arrow Keys** – Fly the chopper
-- **Space / Left Mouse** – Primary cannon
+- **Space / Left Mouse** – Missiles
 - **Shift / Right Mouse** – Rockets
-- **E / Middle Mouse / X** – Missiles
+- **E / Middle Mouse / X** – Hellfire missiles
 - **R / Q / Tab** – Cycle weapons (1/2/3 for direct selection)
 - **Esc** – Pause / Resume / Back
 - **M** – Toggle mute

--- a/src/core/audio/sfx.ts
+++ b/src/core/audio/sfx.ts
@@ -46,7 +46,7 @@ export class EngineSound {
   }
 }
 
-export function playCannon(bus: AudioBus): void {
+export function playMissile(bus: AudioBus): void {
   const ctx = bus.context;
   const osc = ctx.createOscillator();
   const gain = ctx.createGain();
@@ -78,7 +78,7 @@ export function playRocket(bus: AudioBus): void {
   osc.stop(t + 0.28);
 }
 
-export function playMissile(bus: AudioBus): void {
+export function playHellfire(bus: AudioBus): void {
   const ctx = bus.context;
   const osc = ctx.createOscillator();
   const gain = ctx.createGain();

--- a/src/game/components/Ammo.ts
+++ b/src/game/components/Ammo.ts
@@ -1,8 +1,8 @@
 export interface Ammo {
-  cannon: number;
-  cannonMax: number;
-  rockets: number;
-  rocketsMax: number;
   missiles: number;
   missilesMax: number;
+  rockets: number;
+  rocketsMax: number;
+  hellfires: number;
+  hellfiresMax: number;
 }

--- a/src/game/components/Pickup.ts
+++ b/src/game/components/Pickup.ts
@@ -8,9 +8,9 @@ export interface Pickup {
   duration: number;
   fuelAmount?: number;
   ammo?: {
-    cannon?: number;
-    rockets?: number;
     missiles?: number;
+    rockets?: number;
+    hellfires?: number;
   };
   survivorCount?: number;
   collectingBy: Entity | null;

--- a/src/game/components/Weapon.ts
+++ b/src/game/components/Weapon.ts
@@ -1,8 +1,8 @@
-export type WeaponKind = 'cannon' | 'rocket' | 'missile';
+export type WeaponKind = 'missile' | 'rocket' | 'hellfire';
 
 export interface WeaponHolder {
   active: WeaponKind;
-  cooldownCannon: number;
-  cooldownRocket: number;
   cooldownMissile: number;
+  cooldownRocket: number;
+  cooldownHellfire: number;
 }

--- a/src/game/systems/AIControl.ts
+++ b/src/game/systems/AIControl.ts
@@ -38,7 +38,7 @@ export class AIControlSystem implements System {
       const dpy = dirX * sn + dirY * cs;
       this.fireEvents.push({
         faction: 'enemy',
-        kind: 'cannon',
+        kind: 'missile',
         sx: t.tx,
         sy: t.ty,
         dx: dpx,
@@ -47,7 +47,7 @@ export class AIControlSystem implements System {
       });
     });
 
-    // SAM: lock and fire missile
+    // SAM: lock and fire hellfire missile
     this.sams.forEach((_e, sam) => {
       sam.cooldown = Math.max(0, sam.cooldown - dt);
       const t = this.transforms.get(_e);
@@ -66,7 +66,7 @@ export class AIControlSystem implements System {
         const dirY = dy / (dist || 1);
         this.fireEvents.push({
           faction: 'enemy',
-          kind: 'missile',
+          kind: 'hellfire',
           x: t.tx,
           y: t.ty,
           vx: dirX * sam.missileSpeed,

--- a/src/game/systems/EnemyBehavior.ts
+++ b/src/game/systems/EnemyBehavior.ts
@@ -51,7 +51,7 @@ export class EnemyBehaviorSystem implements System {
         const ny = dy / (dist || 1);
         this.fireEvents.push({
           faction: 'enemy',
-          kind: 'cannon',
+          kind: 'missile',
           sx: t.tx,
           sy: t.ty,
           dx: nx,
@@ -88,7 +88,7 @@ export class EnemyBehaviorSystem implements System {
         const dirY = (dx / dist) * sn + (dy / dist) * cs;
         this.fireEvents.push({
           faction: 'enemy',
-          kind: 'cannon',
+          kind: 'missile',
           sx: t.tx,
           sy: t.ty,
           dx: dirX,

--- a/src/game/systems/Projectile.ts
+++ b/src/game/systems/Projectile.ts
@@ -4,7 +4,7 @@ import type { Collider } from '../components/Collider';
 import type { DamageTag } from '../components/DamageTag';
 
 export interface Projectile {
-  kind: 'rocket' | 'missile' | 'cannon';
+  kind: 'rocket' | 'hellfire' | 'missile';
   faction: 'player' | 'enemy';
   x: number; // tile-space
   y: number;
@@ -64,7 +64,14 @@ export class ProjectilePool {
       pr.x += pr.vx * dt;
       pr.y += pr.vy * dt;
       pr.ttl -= dt;
-      if (pr.ttl <= 0) continue; // expired
+      if (pr.ttl <= 0) {
+        if (pr.kind === 'missile') {
+          const amount = pr.damage.amount;
+          const rad = pr.damage.radius ?? 0.05;
+          onHit({ x: pr.x, y: pr.y, radius: rad, amount });
+        }
+        continue; // expired
+      }
 
       // Very simple collision check with colliders; stop on first hit
       let hit = false;
@@ -109,16 +116,29 @@ export class ProjectilePool {
       const iy = (p.x + p.y) * halfH;
       ctx.save();
       ctx.translate(originX + ix, originY + iy - 6);
-      if (p.kind === 'cannon') {
-        ctx.fillStyle = '#ffd166';
-        ctx.fillRect(-1, -1, 2, 2);
+      if (p.kind === 'missile') {
+        const dirScreenX = (p.vx - p.vy) * halfW;
+        const dirScreenY = (p.vx + p.vy) * halfH;
+        const dirLen = Math.hypot(dirScreenX, dirScreenY) || 1;
+        const tailLength = Math.min(12, dirLen * 0.18);
+        ctx.strokeStyle = '#ffba08';
+        ctx.lineWidth = 2;
+        ctx.lineCap = 'round';
+        ctx.beginPath();
+        ctx.moveTo(0, 0);
+        ctx.lineTo(-dirScreenX / dirLen * tailLength, -dirScreenY / dirLen * tailLength);
+        ctx.stroke();
+        ctx.fillStyle = '#ffe066';
+        ctx.beginPath();
+        ctx.arc(0, 0, 1.8, 0, Math.PI * 2);
+        ctx.fill();
       } else if (p.kind === 'rocket') {
         ctx.fillStyle = '#ef476f';
         ctx.fillRect(-2, -1, 4, 2);
       } else {
-        ctx.fillStyle = '#118ab2';
+        ctx.fillStyle = '#ff6f59';
         ctx.beginPath();
-        ctx.arc(0, 0, 2.5, 0, Math.PI * 2);
+        ctx.arc(0, 0, 3.2, 0, Math.PI * 2);
         ctx.fill();
       }
       ctx.restore();

--- a/src/game/systems/WeaponFire.ts
+++ b/src/game/systems/WeaponFire.ts
@@ -10,7 +10,7 @@ import { RNG } from '../../core/util/rng';
 export type FireEvent =
   | {
       faction: 'player' | 'enemy';
-      kind: 'cannon';
+      kind: 'missile';
       sx: number;
       sy: number;
       dx: number;
@@ -20,17 +20,22 @@ export type FireEvent =
       ttl?: number;
       radius?: number;
       damage?: number;
+      damageRadius?: number;
     }
   | { faction: 'player' | 'enemy'; kind: 'rocket'; x: number; y: number; vx: number; vy: number }
   | {
       faction: 'player' | 'enemy';
-      kind: 'missile';
+      kind: 'hellfire';
       x: number;
       y: number;
       vx: number;
       vy: number;
       targetX: number;
       targetY: number;
+      ttl?: number;
+      radius?: number;
+      damage?: number;
+      damageRadius?: number;
     };
 
 export class WeaponFireSystem implements System {
@@ -62,9 +67,9 @@ export class WeaponFireSystem implements System {
   update(dt: number): void {
     // Cooldowns decay
     this.weapons.forEach((entity, w) => {
-      w.cooldownCannon = Math.max(0, w.cooldownCannon - dt);
-      w.cooldownRocket = Math.max(0, w.cooldownRocket - dt);
       w.cooldownMissile = Math.max(0, w.cooldownMissile - dt);
+      w.cooldownRocket = Math.max(0, w.cooldownRocket - dt);
+      w.cooldownHellfire = Math.max(0, w.cooldownHellfire - dt);
     });
 
     const snap = this.input;
@@ -99,9 +104,9 @@ export class WeaponFireSystem implements System {
       const ammo = this.ammo.get(entity);
       if (!ph || !ammo) return;
 
-      if (snap.keys['1']) w.active = 'cannon';
+      if (snap.keys['1']) w.active = 'missile';
       else if (snap.keys['2']) w.active = 'rocket';
-      else if (snap.keys['3']) w.active = 'missile';
+      else if (snap.keys['3']) w.active = 'hellfire';
 
       // Aim direction from entity to aim tile
       const ax = this.aimTileX - t.tx;
@@ -111,11 +116,11 @@ export class WeaponFireSystem implements System {
       const dirY = ay / ad;
 
       // Active-weapon fire (also direct-mapped buttons)
-      if ((w.active === 'cannon' && (isLmb || primaryKey)) || isLmb || primaryKey) {
-        // Cannon: short cooldown, spread, hitscan
-        if (w.cooldownCannon <= 0 && ammo.cannon > 0) {
-          w.cooldownCannon = 0.08;
-          ammo.cannon = Math.max(0, ammo.cannon - 1);
+      if ((w.active === 'missile' && (isLmb || primaryKey)) || isLmb || primaryKey) {
+        // Missile: short cooldown, spread, small AoE
+        if (w.cooldownMissile <= 0 && ammo.missiles > 0) {
+          w.cooldownMissile = 0.1;
+          ammo.missiles = Math.max(0, ammo.missiles - 1);
           const spread = 0.08; // radians
           const jitter = (this.rng.float01() - 0.5) * 2 * spread;
           const cs = Math.cos(jitter);
@@ -124,16 +129,17 @@ export class WeaponFireSystem implements System {
           const dy = dirX * sn + dirY * cs;
           this.eventsOut.push({
             faction: 'player',
-            kind: 'cannon',
+            kind: 'missile',
             sx: t.tx,
             sy: t.ty,
             dx,
             dy,
             spread,
-            speed: 22,
-            ttl: 1.1,
-            radius: 0.12,
-            damage: 6,
+            speed: 24,
+            ttl: 1.35,
+            radius: 0.16,
+            damage: 10,
+            damageRadius: 0.35,
           });
         }
       }
@@ -154,20 +160,24 @@ export class WeaponFireSystem implements System {
         }
       }
 
-      if ((w.active === 'missile' && (isMmb || specialKey)) || isMmb || specialKey) {
-        if (w.cooldownMissile <= 0 && ammo.missiles > 0) {
-          w.cooldownMissile = 1.0;
-          ammo.missiles = Math.max(0, ammo.missiles - 1);
+      if ((w.active === 'hellfire' && (isMmb || specialKey)) || isMmb || specialKey) {
+        if (w.cooldownHellfire <= 0 && ammo.hellfires > 0) {
+          w.cooldownHellfire = 1.25;
+          ammo.hellfires = Math.max(0, ammo.hellfires - 1);
           const speed = 5.5;
           this.eventsOut.push({
             faction: 'player',
-            kind: 'missile',
+            kind: 'hellfire',
             x: t.tx,
             y: t.ty,
             vx: dirX * speed,
             vy: dirY * speed,
             targetX: this.aimTileX,
             targetY: this.aimTileY,
+            ttl: 6,
+            radius: 0.22,
+            damage: 32,
+            damageRadius: 1.25,
           });
         }
       }
@@ -176,7 +186,7 @@ export class WeaponFireSystem implements System {
 }
 
 function nextWeapon(k: WeaponKind): WeaponKind {
-  if (k === 'cannon') return 'rocket';
-  if (k === 'rocket') return 'missile';
-  return 'cannon';
+  if (k === 'missile') return 'rocket';
+  if (k === 'rocket') return 'hellfire';
+  return 'missile';
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -51,7 +51,7 @@ import { drawHUD } from './ui/hud/hud';
 import { loadJson, saveJson } from './core/util/storage';
 import { loadBindings, isDown } from './ui/input-remap/bindings';
 import { AudioBus } from './core/audio/audio';
-import { EngineSound, playCannon, playRocket, playMissile, playExplosion } from './core/audio/sfx';
+import { EngineSound, playMissile, playRocket, playHellfire, playExplosion } from './core/audio/sfx';
 import { CameraShake } from './render/camera/shake';
 import { getCanvasViewMetrics } from './render/canvas/metrics';
 import { drawPickupCrate } from './render/sprites/pickups';
@@ -83,7 +83,7 @@ interface PickupSite {
   radius?: number;
   duration?: number;
   fuelAmount?: number;
-  ammo?: { cannon?: number; rockets?: number; missiles?: number };
+  ammo?: { missiles?: number; rockets?: number; hellfires?: number };
 }
 
 interface SurvivorSite {
@@ -230,14 +230,14 @@ physics.set(player, {
 fuels.set(player, { current: 65, max: 100 });
 sprites.set(player, { color: '#92ffa6', rotor: 0 });
 ammos.set(player, {
-  cannon: 200,
-  cannonMax: 200,
+  missiles: 200,
+  missilesMax: 200,
   rockets: 12,
   rocketsMax: 12,
-  missiles: 6,
-  missilesMax: 6,
+  hellfires: 2,
+  hellfiresMax: 2,
 });
-weapons.set(player, { active: 'cannon', cooldownCannon: 0, cooldownRocket: 0, cooldownMissile: 0 });
+weapons.set(player, { active: 'missile', cooldownMissile: 0, cooldownRocket: 0, cooldownHellfire: 0 });
 healths.set(player, { current: 100, max: 100 });
 colliders.set(player, { radius: 0.4, team: 'player' });
 
@@ -379,14 +379,14 @@ const alienSpawnPoints: { tx: number; ty: number }[] = [
 
 const pickupSites: PickupSite[] = [
   { tx: 15.2, ty: 18.4, kind: 'fuel', fuelAmount: 55 },
-  { tx: 18.6, ty: 16.1, kind: 'ammo', ammo: { cannon: 90, rockets: 3, missiles: 1 } },
-  { tx: 10.4, ty: 12.6, kind: 'ammo', ammo: { cannon: 110, rockets: 4, missiles: 2 } },
+  { tx: 18.6, ty: 16.1, kind: 'ammo', ammo: { missiles: 90, rockets: 3, hellfires: 1 } },
+  { tx: 10.4, ty: 12.6, kind: 'ammo', ammo: { missiles: 110, rockets: 4, hellfires: 1 } },
   { tx: 22.5, ty: 12.2, kind: 'fuel', fuelAmount: 60 },
-  { tx: 25.3, ty: 19.4, kind: 'ammo', ammo: { cannon: 100, rockets: 5, missiles: 2 } },
+  { tx: 25.3, ty: 19.4, kind: 'ammo', ammo: { missiles: 100, rockets: 5, hellfires: 1 } },
   { tx: 28.2, ty: 27.1, kind: 'fuel', fuelAmount: 65 },
   { tx: 13.2, ty: 26.4, kind: 'fuel', fuelAmount: 58 },
-  { tx: 7.4, ty: 22.3, kind: 'ammo', ammo: { cannon: 80, rockets: 3, missiles: 1 } },
-  { tx: 31.2, ty: 14.4, kind: 'ammo', ammo: { cannon: 95, rockets: 3, missiles: 2 } },
+  { tx: 7.4, ty: 22.3, kind: 'ammo', ammo: { missiles: 80, rockets: 3, hellfires: 1 } },
+  { tx: 31.2, ty: 14.4, kind: 'ammo', ammo: { missiles: 95, rockets: 3, hellfires: 1 } },
   { tx: 20.4, ty: 29.1, kind: 'fuel', fuelAmount: 62 },
 ];
 
@@ -595,9 +595,9 @@ function spawnPickups(): void {
       ammo:
         site.kind === 'ammo'
           ? {
-              cannon: site.ammo?.cannon ?? 80,
+              missiles: site.ammo?.missiles ?? 80,
               rockets: site.ammo?.rockets ?? 3,
-              missiles: site.ammo?.missiles ?? 1,
+              hellfires: site.ammo?.hellfires ?? 0,
             }
           : undefined,
       collectingBy: null,
@@ -759,9 +759,9 @@ function resetPlayer(): void {
     ph.ax = 0;
     ph.ay = 0;
     fuel.current = fuel.max;
-    ammo.cannon = ammo.cannonMax;
-    ammo.rockets = ammo.rocketsMax;
     ammo.missiles = ammo.missilesMax;
+    ammo.rockets = ammo.rocketsMax;
+    ammo.hellfires = ammo.hellfiresMax;
     health.current = health.max;
     colliders.set(player, { radius: 0.4, team: 'player' });
   }
@@ -1002,7 +1002,7 @@ const loop = new GameLoop({
       entity: Entity;
       kind: Pickup['kind'];
       fuelAmount?: number;
-      ammo?: { cannon?: number; rockets?: number; missiles?: number };
+      ammo?: { missiles?: number; rockets?: number; hellfires?: number };
       survivorCount?: number;
     }[] = [];
     pickups.forEach((entity, pickup) => {
@@ -1058,9 +1058,9 @@ const loop = new GameLoop({
             }
           } else if (pickup.kind === 'ammo') {
             const needsAmmo =
-              playerAmmo.cannon < playerAmmo.cannonMax ||
+              playerAmmo.missiles < playerAmmo.missilesMax ||
               playerAmmo.rockets < playerAmmo.rocketsMax ||
-              playerAmmo.missiles < playerAmmo.missilesMax;
+              playerAmmo.hellfires < playerAmmo.hellfiresMax;
             if (needsAmmo) {
               pickup.collectingBy = player;
               pickup.progress = 0;
@@ -1083,10 +1083,6 @@ const loop = new GameLoop({
         const amount = item.fuelAmount ?? 50;
         playerFuel.current = Math.min(playerFuel.max, playerFuel.current + amount);
       } else if (item.kind === 'ammo' && item.ammo) {
-        playerAmmo.cannon = Math.min(
-          playerAmmo.cannonMax,
-          playerAmmo.cannon + (item.ammo.cannon ?? 0),
-        );
         playerAmmo.rockets = Math.min(
           playerAmmo.rocketsMax,
           playerAmmo.rockets + (item.ammo.rockets ?? 0),
@@ -1094,6 +1090,10 @@ const loop = new GameLoop({
         playerAmmo.missiles = Math.min(
           playerAmmo.missilesMax,
           playerAmmo.missiles + (item.ammo.missiles ?? 0),
+        );
+        playerAmmo.hellfires = Math.min(
+          playerAmmo.hellfiresMax,
+          playerAmmo.hellfires + (item.ammo.hellfires ?? 0),
         );
       } else if (item.kind === 'survivor') {
         const count = item.survivorCount ?? 1;
@@ -1124,19 +1124,19 @@ const loop = new GameLoop({
 
     for (let i = 0; i < fireEvents.length; i += 1) {
       const ev = fireEvents[i]!;
-      if (ev.kind === 'cannon') {
-        playCannon(bus);
-        const speedC = ev.speed ?? 18;
+      if (ev.kind === 'missile') {
+        playMissile(bus);
+        const speedM = ev.speed ?? 24;
         projectilePool.spawn({
-          kind: 'cannon',
+          kind: 'missile',
           faction: ev.faction,
           x: ev.sx,
           y: ev.sy,
-          vx: ev.dx * speedC,
-          vy: ev.dy * speedC,
-          ttl: ev.ttl ?? 0.8,
-          radius: ev.radius ?? 0.08,
-          damage: { amount: ev.damage ?? 4 },
+          vx: ev.dx * speedM,
+          vy: ev.dy * speedM,
+          ttl: ev.ttl ?? 1.3,
+          radius: ev.radius ?? 0.14,
+          damage: { amount: ev.damage ?? 10, radius: ev.damageRadius ?? 0.35 },
         });
       } else if (ev.kind === 'rocket') {
         playRocket(bus);
@@ -1151,25 +1151,26 @@ const loop = new GameLoop({
           radius: ev.radius ?? 0.18,
           damage: { amount: 12, radius: 0.6 },
         });
-      } else if (ev.kind === 'missile') {
-        playMissile(bus);
+      } else if (ev.kind === 'hellfire') {
+        playHellfire(bus);
         projectilePool.spawn({
-          kind: 'missile',
+          kind: 'hellfire',
           faction: ev.faction,
           x: ev.x,
           y: ev.y,
           vx: ev.vx,
           vy: ev.vy,
           ttl: ev.ttl ?? 6,
-          radius: ev.radius ?? 0.18,
+          radius: ev.radius ?? 0.22,
           seek: { targetX: ev.targetX, targetY: ev.targetY, turnRate: Math.PI * 0.8 },
-          damage: { amount: 18, radius: 0.9 },
+          damage: { amount: ev.damage ?? 28, radius: ev.damageRadius ?? 1.15 },
         });
       }
     }
     fireEvents.length = 0;
 
     projectilePool.update(dt, colliders, colliders, transforms, (hit) => {
+      spawnExplosion(hit.x, hit.y);
       damage.queue(hit);
       playExplosion(bus);
       if (ui.settings.screenShake) shake.trigger(8, 0.25);
@@ -1408,14 +1409,14 @@ const loop = new GameLoop({
         fuelMax: fuelComp.max,
         armor01: healthComp.current / healthComp.max,
         ammo: {
-          cannon: ammoComp.cannon,
-          rockets: ammoComp.rockets,
           missiles: ammoComp.missiles,
+          rockets: ammoComp.rockets,
+          hellfires: ammoComp.hellfires,
         },
         ammoMax: {
-          cannon: ammoComp.cannonMax,
-          rockets: ammoComp.rocketsMax,
           missiles: ammoComp.missilesMax,
+          rockets: ammoComp.rocketsMax,
+          hellfires: ammoComp.hellfiresMax,
         },
         activeWeapon: weaponComp.active,
         lives: Math.max(0, playerState.lives),

--- a/src/ui/hud/hud.ts
+++ b/src/ui/hud/hud.ts
@@ -6,8 +6,8 @@ export interface BarsData {
   fuelCurrent: number;
   fuelMax: number;
   armor01: number;
-  ammo: { cannon: number; rockets: number; missiles: number };
-  ammoMax: { cannon: number; rockets: number; missiles: number };
+  ammo: { missiles: number; rockets: number; hellfires: number };
+  ammoMax: { missiles: number; rockets: number; hellfires: number };
   activeWeapon: string;
   lives: number;
   score: number;
@@ -41,9 +41,9 @@ export function drawHUD(
   const fuelText = `Fuel: ${Math.round(bars.fuelCurrent)} / ${Math.round(bars.fuelMax)}`;
   ctx.fillText(fuelText, x0, y0 - 78);
   const ammoText =
-    `Ammo  C:${bars.ammo.cannon}/${bars.ammoMax.cannon}  ` +
+    `Ammo  M:${bars.ammo.missiles}/${bars.ammoMax.missiles}  ` +
     `R:${bars.ammo.rockets}/${bars.ammoMax.rockets}  ` +
-    `M:${bars.ammo.missiles}/${bars.ammoMax.missiles}  [` +
+    `H:${bars.ammo.hellfires}/${bars.ammoMax.hellfires}  [` +
     `${bars.activeWeapon.toUpperCase()}]`;
   ctx.fillText(ammoText, x0, y0 - 60);
   ctx.fillStyle = '#c8d7e1';


### PR DESCRIPTION
## Summary
- rename the cannon and missile loadouts to missiles and hellfire missiles across ammo, pickups, UI, and HUD labels
- tune player fire logic to give missiles small AoE damage and slow, high-impact hellfire salvos with updated audio cues
- update AI launchers and projectile visuals to use the new weapon types and damage expectations
- accelerate missiles and trigger on-impact explosions with new streak visuals so they detonate in a satisfying kaboom when a target or the ground is reached

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68cdba235de88327bb901371729e8d4f