### PR TITLE
Retheme defenses with alien strongholds and mission briefing

### DIFF
--- a/src/game/components/Pickup.ts
+++ b/src/game/components/Pickup.ts
@@ -1,6 +1,6 @@
 import type { Entity } from '../../core/ecs/entities';
 
-export type PickupKind = 'fuel' | 'ammo' | 'survivor';
+export type PickupKind = 'fuel' | 'ammo' | 'survivor' | 'armor';
 
 export interface Pickup {
   kind: PickupKind;
@@ -13,6 +13,7 @@ export interface Pickup {
     hellfires?: number;
   };
   survivorCount?: number;
+  armorAmount?: number;
   collectingBy: Entity | null;
   progress: number;
 }

--- a/src/game/data/missions/sample_mission.json
+++ b/src/game/data/missions/sample_mission.json
@@ -1,34 +1,34 @@
 {
   "id": "m01",
-  "title": "Expanded Foothold",
-  "briefing": "Push across the valley, neutralize air defenses, level the command campus, repel the alien responders, evacuate survivors, and return to base.",
+  "title": "Operation Dawnshield",
+  "briefing": "Alien strongholds anchor an invasion corridor through the valley. Neutralize their forward defenses, demolish the command campus, and evacuate anyone left standing before the counterattack closes in.",
   "startPos": { "tx": 31, "ty": 31 },
   "objectives": [
     {
       "id": "obj1",
       "type": "destroy",
-      "name": "Neutralize western AAA turret",
+      "name": "Destroy the valley stronghold",
       "at": { "tx": 11, "ty": 15 },
       "radiusTiles": 1.6
     },
     {
       "id": "obj2",
       "type": "destroy",
-      "name": "Neutralize ridge-line SAM",
+      "name": "Disable the ridge command nexus",
       "at": { "tx": 26, "ty": 11 },
       "radiusTiles": 1.6
     },
     {
       "id": "obj3",
       "type": "destroy",
-      "name": "Level the command campus",
+      "name": "Level the alien command campus",
       "at": { "tx": 18, "ty": 18 },
       "radiusTiles": 5
     },
     {
       "id": "obj4",
       "type": "custom",
-      "name": "Crush the alien vanguard",
+      "name": "Break the alien counterattack",
       "at": { "tx": 18, "ty": 18 },
       "radiusTiles": 6
     },

--- a/src/render/sprites/pickups.ts
+++ b/src/render/sprites/pickups.ts
@@ -126,6 +126,22 @@ export function drawPickupCrate(
     ctx.beginPath();
     ctx.roundRect(-5, 2, 10, 3.5, 1.5);
     ctx.fill();
+  } else if (params.kind === 'armor') {
+    ctx.beginPath();
+    ctx.moveTo(0, -6);
+    ctx.lineTo(6, -2);
+    ctx.quadraticCurveTo(0, 8, 0, 8);
+    ctx.quadraticCurveTo(0, 8, -6, -2);
+    ctx.closePath();
+    ctx.fill();
+    ctx.fillStyle = shadeColor(palette.icon, -35);
+    ctx.beginPath();
+    ctx.moveTo(0, -3.5);
+    ctx.lineTo(3.6, -1.2);
+    ctx.quadraticCurveTo(0, 5.5, 0, 5.5);
+    ctx.quadraticCurveTo(0, 5.5, -3.6, -1.2);
+    ctx.closePath();
+    ctx.fill();
   } else {
     ctx.beginPath();
     ctx.roundRect(-7, -3, 14, 6, 2);
@@ -193,6 +209,14 @@ function getPalette(kind: PickupKind): {
       top: '#4054a1',
       straps: '#1c2446',
       icon: '#f4f6ff',
+    };
+  }
+  if (kind === 'armor') {
+    return {
+      body: '#1d4b59',
+      top: '#266c7b',
+      straps: '#0f2e36',
+      icon: '#9df2ff',
     };
   }
   return {

--- a/src/render/sprites/targets.ts
+++ b/src/render/sprites/targets.ts
@@ -14,19 +14,54 @@ export function drawAAATurret(
   const iy = (tx + ty) * halfH;
   ctx.save();
   ctx.translate(originX + ix, originY + iy);
-  ctx.fillStyle = '#444f5a';
-  ctx.strokeStyle = '#2b3640';
-  ctx.lineWidth = 2;
+  ctx.fillStyle = 'rgba(0, 0, 0, 0.4)';
   ctx.beginPath();
-  ctx.roundRect(-6, -6, 12, 12, 2);
+  ctx.ellipse(0, 10, 18, 10, 0, 0, Math.PI * 2);
   ctx.fill();
-  ctx.stroke();
-  // barrel
-  ctx.strokeStyle = '#9fb3c8';
+
+  ctx.fillStyle = '#1c1030';
+  ctx.beginPath();
+  ctx.moveTo(-16, 8);
+  ctx.lineTo(0, -10);
+  ctx.lineTo(16, 8);
+  ctx.lineTo(0, 16);
+  ctx.closePath();
+  ctx.fill();
+
+  ctx.strokeStyle = '#63fce0';
   ctx.lineWidth = 3;
   ctx.beginPath();
-  ctx.moveTo(0, 0);
-  ctx.lineTo(10, -3);
+  ctx.ellipse(0, -2, 11, 6, 0, 0, Math.PI * 2);
+  ctx.stroke();
+
+  ctx.fillStyle = '#2a1548';
+  ctx.beginPath();
+  ctx.roundRect(-9, -16, 18, 16, 6);
+  ctx.fill();
+
+  ctx.fillStyle = '#9bfff1';
+  ctx.beginPath();
+  ctx.arc(0, -8, 5, 0, Math.PI * 2);
+  ctx.fill();
+
+  ctx.strokeStyle = '#c7a4ff';
+  ctx.lineWidth = 3;
+  ctx.beginPath();
+  ctx.moveTo(-11, -3);
+  ctx.lineTo(-20, -11);
+  ctx.moveTo(11, -3);
+  ctx.lineTo(20, -11);
+  ctx.stroke();
+
+  ctx.strokeStyle = '#6dfcdf';
+  ctx.lineWidth = 2;
+  ctx.beginPath();
+  ctx.moveTo(0, -16);
+  ctx.lineTo(0, -26);
+  ctx.moveTo(-5, -14);
+  ctx.lineTo(-7, -22);
+  ctx.moveTo(5, -14);
+  ctx.lineTo(7, -22);
   ctx.stroke();
   ctx.restore();
 }
@@ -45,16 +80,61 @@ export function drawSAM(
   const iy = (tx + ty) * halfH;
   ctx.save();
   ctx.translate(originX + ix, originY + iy);
-  ctx.fillStyle = '#364d3b';
-  ctx.strokeStyle = '#223326';
+  ctx.fillStyle = 'rgba(0, 0, 0, 0.45)';
+  ctx.beginPath();
+  ctx.ellipse(0, 12, 22, 12, 0, 0, Math.PI * 2);
+  ctx.fill();
+
+  ctx.fillStyle = '#111b36';
+  ctx.beginPath();
+  ctx.moveTo(-20, 10);
+  ctx.lineTo(0, -16);
+  ctx.lineTo(20, 10);
+  ctx.lineTo(0, 20);
+  ctx.closePath();
+  ctx.fill();
+
+  ctx.fillStyle = '#1f2e57';
+  ctx.beginPath();
+  ctx.moveTo(-14, 8);
+  ctx.lineTo(0, -6);
+  ctx.lineTo(14, 8);
+  ctx.lineTo(0, 14);
+  ctx.closePath();
+  ctx.fill();
+
+  ctx.fillStyle = '#2a1552';
+  ctx.beginPath();
+  ctx.roundRect(-12, -22, 24, 20, 8);
+  ctx.fill();
+
+  ctx.fillStyle = '#7ff4ff';
+  ctx.beginPath();
+  ctx.roundRect(-7, -18, 14, 12, 4);
+  ctx.fill();
+
+  ctx.fillStyle = '#3a1d60';
+  ctx.beginPath();
+  ctx.moveTo(-17, 6);
+  ctx.lineTo(-25, -8);
+  ctx.lineTo(-13, -14);
+  ctx.closePath();
+  ctx.moveTo(17, 6);
+  ctx.lineTo(25, -8);
+  ctx.lineTo(13, -14);
+  ctx.closePath();
+  ctx.fill();
+
+  ctx.fillStyle = '#96fff6';
+  ctx.beginPath();
+  ctx.arc(0, -24, 6, 0, Math.PI * 2);
+  ctx.fill();
+  ctx.strokeStyle = '#63fce0';
   ctx.lineWidth = 2;
   ctx.beginPath();
-  ctx.roundRect(-6, -6, 12, 12, 2);
-  ctx.fill();
+  ctx.moveTo(0, -24);
+  ctx.lineTo(0, -34);
   ctx.stroke();
-  // tube
-  ctx.fillStyle = '#cfe3d3';
-  ctx.fillRect(-2, -10, 4, 8);
   ctx.restore();
 }
 

--- a/src/ui/menus/scenes.ts
+++ b/src/ui/menus/scenes.ts
@@ -3,6 +3,7 @@ export type UIState =
   | 'settings'
   | 'achievements'
   | 'about'
+  | 'briefing'
   | 'in-game'
   | 'paused'
   | 'win'


### PR DESCRIPTION
## Summary
- add a mission briefing state and overlay so the player receives Operation Dawnshield goals before the sortie
- scatter random destructible civilian houses, including an armor-drop hideout, and have AAA/SAM spawns grow into alien strongholds with defenders
- retheme SAM/AAA visuals and pickups while updating mission text for the alien incursion

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68ceaa044b78832798b4f4684ec70d52