### PR TITLE
Disable context menu on game canvas

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -153,6 +153,11 @@ if (!canvas) throw new Error('Canvas element with id "game" not found');
 const context = canvas.getContext('2d');
 if (!context) throw new Error('Failed to get 2D context');
 
+// Disable right-click context menu on the game canvas only
+canvas.addEventListener('contextmenu', (e) => {
+  e.preventDefault();
+});
+
 function resizeCanvasToDisplaySize(): void {
   const dpr = Math.max(1, window.devicePixelRatio || 1);
   const displayWidth = Math.floor(canvas.clientWidth * dpr);


### PR DESCRIPTION
## Summary
- prevent the browser context menu from appearing when right-clicking on the game canvas

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68cec0d7a09c8327b34ad0abeba03077