### PR TITLE
Add strafing controls and remap weapon keys

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,10 +27,11 @@ production.
 ## Controls
 
 - **WASD / Arrow Keys** – Fly the chopper
+- **Q / E** – Strafe left / right
 - **Space / Left Mouse** – Missiles
 - **Shift / Right Mouse** – Rockets
-- **E / Middle Mouse / X** – Hellfire missiles
-- **R / Q / Tab** – Cycle weapons (1/2/3 for direct selection)
+- **C / Middle Mouse / X** – Hellfire missiles
+- **R / F / Tab** – Cycle weapons (1/2/3 for direct selection)
 - **Esc** – Pause / Resume / Back
 - **M** – Toggle mute
 

--- a/src/game/systems/WeaponFire.ts
+++ b/src/game/systems/WeaponFire.ts
@@ -91,7 +91,7 @@ export class WeaponFireSystem implements System {
 
     // Cycle weapon
     const switchDown =
-      snap.keys['r'] || snap.keys['R'] || snap.keys['q'] || snap.keys['Q'] || snap.keys['Tab'];
+      snap.keys['r'] || snap.keys['R'] || snap.keys['f'] || snap.keys['F'] || snap.keys['Tab'];
     if (switchDown && !this.switchHeld) {
       this.weapons.forEach((_, w) => {
         w.active = nextWeapon(w.active);
@@ -109,7 +109,7 @@ export class WeaponFireSystem implements System {
       snap.keys['ShiftLeft'] ||
       snap.keys['ShiftRight'] ||
       snap.keys['Control'];
-    const specialKey = snap.keys['e'] || snap.keys['E'] || snap.keys['x'] || snap.keys['X'];
+    const specialKey = snap.keys['c'] || snap.keys['C'] || snap.keys['x'] || snap.keys['X'];
 
     this.weapons.forEach((entity, w) => {
       const t = this.transforms.get(entity);

--- a/src/main.ts
+++ b/src/main.ts
@@ -1257,6 +1257,8 @@ const loop = new GameLoop({
       if (isDown(snap, bindings, 'moveDown')) dy += 1;
       if (isDown(snap, bindings, 'moveLeft')) dx -= 1;
       if (isDown(snap, bindings, 'moveRight')) dx += 1;
+      if (isDown(snap, bindings, 'strafeLeft')) dx -= 1;
+      if (isDown(snap, bindings, 'strafeRight')) dx += 1;
     }
     if (dx !== 0 || dy !== 0) {
       const len = Math.hypot(dx, dy) || 1;

--- a/src/ui/input-remap/bindings.ts
+++ b/src/ui/input-remap/bindings.ts
@@ -1,7 +1,14 @@
 import type { InputSnapshot } from '../../core/input/input';
 import { loadJson, saveJson } from '../../core/util/storage';
 
-export type Action = 'moveUp' | 'moveDown' | 'moveLeft' | 'moveRight' | 'pause';
+export type Action =
+  | 'moveUp'
+  | 'moveDown'
+  | 'moveLeft'
+  | 'moveRight'
+  | 'strafeLeft'
+  | 'strafeRight'
+  | 'pause';
 
 export type KeyBindings = Record<Action, string[]>; // array of key values
 
@@ -13,12 +20,24 @@ export function defaultBindings(): KeyBindings {
     moveDown: ['s', 'S', 'ArrowDown'],
     moveLeft: ['a', 'A', 'ArrowLeft'],
     moveRight: ['d', 'D', 'ArrowRight'],
+    strafeLeft: ['q', 'Q'],
+    strafeRight: ['e', 'E'],
     pause: ['Escape'],
   };
 }
 
 export function loadBindings(): KeyBindings {
-  return loadJson<KeyBindings>(STORAGE_KEY, defaultBindings());
+  const stored = loadJson<KeyBindings>(STORAGE_KEY, defaultBindings());
+  const defaults = defaultBindings();
+  return {
+    moveUp: stored.moveUp ?? defaults.moveUp,
+    moveDown: stored.moveDown ?? defaults.moveDown,
+    moveLeft: stored.moveLeft ?? defaults.moveLeft,
+    moveRight: stored.moveRight ?? defaults.moveRight,
+    strafeLeft: stored.strafeLeft ?? defaults.strafeLeft,
+    strafeRight: stored.strafeRight ?? defaults.strafeRight,
+    pause: stored.pause ?? defaults.pause,
+  };
 }
 
 export function saveBindings(b: KeyBindings): void {


### PR DESCRIPTION
## Summary
- add dedicated strafe left/right actions defaulted to Q/E and incorporate them into player acceleration logic
- remap the weapon cycle to also use F and move the hellfire trigger to the C key
- refresh stored key binding defaults and README controls to document the new mappings

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d0558d3d448327bc38a9a8b40a8316