### PR TITLE
Add ocean mission with speedboat assault

### DIFF
--- a/src/game/components/Speedboat.ts
+++ b/src/game/components/Speedboat.ts
@@ -1,0 +1,10 @@
+export interface Speedboat {
+  targetX: number;
+  targetY: number;
+  speed: number;
+  acceleration: number;
+  fireRange: number;
+  fireInterval: number;
+  cooldown: number;
+  arrivalRadius: number;
+}

--- a/src/game/data/missions/ocean_mission.json
+++ b/src/game/data/missions/ocean_mission.json
@@ -1,0 +1,49 @@
+{
+  "id": "m02",
+  "title": "Operation Stormbreak",
+  "briefing": "With the valley secure, alien reinforcements are racing in over the ocean. Launch from the carrier, smash their shoreline command nodes, and stop the speedboat strike teams before they overrun our forward radar relays.",
+  "startPos": { "tx": 30, "ty": 44 },
+  "objectives": [
+    {
+      "id": "obj1",
+      "type": "destroy",
+      "name": "Level the breakwater command spire",
+      "at": { "tx": 26.4, "ty": 16.2 },
+      "radiusTiles": 1.8
+    },
+    {
+      "id": "obj2",
+      "type": "destroy",
+      "name": "Destroy the harbor missile silo",
+      "at": { "tx": 32.5, "ty": 17.4 },
+      "radiusTiles": 1.8
+    },
+    {
+      "id": "obj3",
+      "type": "destroy",
+      "name": "Cripple the shoreline uplink tower",
+      "at": { "tx": 37.2, "ty": 19.6 },
+      "radiusTiles": 1.9
+    },
+    {
+      "id": "boats",
+      "type": "custom",
+      "name": "Hold the coastal perimeter",
+      "at": { "tx": 34.8, "ty": 22.0 },
+      "radiusTiles": 6.5
+    },
+    {
+      "id": "obj6",
+      "type": "reach",
+      "name": "Return to the carrier deck",
+      "requires": ["obj1", "obj2", "obj3", "boats"],
+      "at": { "tx": 30, "ty": 44 },
+      "radiusTiles": 1.5
+    }
+  ],
+  "enemySpawns": [
+    { "type": "AAA", "at": { "tx": 28, "ty": 21 } },
+    { "type": "SAM", "at": { "tx": 34, "ty": 19 } },
+    { "type": "SAM", "at": { "tx": 40, "ty": 22 } }
+  ]
+}

--- a/src/game/systems/SpeedboatBehavior.ts
+++ b/src/game/systems/SpeedboatBehavior.ts
@@ -1,0 +1,76 @@
+import type { System } from '../../core/ecs/systems';
+import type { ComponentStore } from '../../core/ecs/components';
+import type { Transform } from '../components/Transform';
+import type { Physics } from '../components/Physics';
+import type { Speedboat } from '../components/Speedboat';
+import type { FireEvent } from './WeaponFire';
+import type { Entity } from '../../core/ecs/entities';
+import { RNG } from '../../core/util/rng';
+
+export class SpeedboatBehaviorSystem implements System {
+  constructor(
+    private transforms: ComponentStore<Transform>,
+    private physics: ComponentStore<Physics>,
+    private speedboats: ComponentStore<Speedboat>,
+    private fireEvents: FireEvent[],
+    private rng: RNG,
+    private getPlayer: () => { x: number; y: number },
+    private onReachTarget: (entity: Entity) => void,
+  ) {}
+
+  update(dt: number): void {
+    const player = this.getPlayer();
+    const landed: Entity[] = [];
+
+    this.speedboats.forEach((entity, boat) => {
+      const t = this.transforms.get(entity);
+      const phys = this.physics.get(entity);
+      if (!t || !phys) return;
+
+      const dx = boat.targetX - t.tx;
+      const dy = boat.targetY - t.ty;
+      const dist = Math.hypot(dx, dy);
+      if (dist <= boat.arrivalRadius) {
+        landed.push(entity);
+        return;
+      }
+
+      const clampedDist = dist || 1;
+      const desiredVx = (dx / clampedDist) * boat.speed;
+      const desiredVy = (dy / clampedDist) * boat.speed;
+      phys.ax = (desiredVx - phys.vx) * boat.acceleration;
+      phys.ay = (desiredVy - phys.vy) * boat.acceleration;
+
+      boat.cooldown = Math.max(0, boat.cooldown - dt);
+      const px = player.x - t.tx;
+      const py = player.y - t.ty;
+      const pDist = Math.hypot(px, py);
+      if (pDist <= boat.fireRange && boat.cooldown <= 0) {
+        boat.cooldown = boat.fireInterval;
+        const jitter = (this.rng.float01() - 0.5) * 0.18;
+        const cs = Math.cos(jitter);
+        const sn = Math.sin(jitter);
+        const nx = (px / (pDist || 1)) * cs - (py / (pDist || 1)) * sn;
+        const ny = (px / (pDist || 1)) * sn + (py / (pDist || 1)) * cs;
+        this.fireEvents.push({
+          faction: 'enemy',
+          kind: 'missile',
+          sx: t.tx,
+          sy: t.ty,
+          dx: nx,
+          dy: ny,
+          speed: 18,
+          ttl: 0.9,
+          radius: 0.14,
+          damage: 4,
+        });
+      }
+    });
+
+    if (landed.length > 0) {
+      for (let i = 0; i < landed.length; i += 1) {
+        this.onReachTarget(landed[i]!);
+      }
+    }
+  }
+}

--- a/src/render/sprites/targets.ts
+++ b/src/render/sprites/targets.ts
@@ -192,6 +192,59 @@ export function drawChaserDrone(
   ctx.restore();
 }
 
+export function drawSpeedboat(
+  ctx: CanvasRenderingContext2D,
+  iso: IsoParams,
+  originX: number,
+  originY: number,
+  tx: number,
+  ty: number,
+): void {
+  const halfW = iso.tileWidth / 2;
+  const halfH = iso.tileHeight / 2;
+  const ix = (tx - ty) * halfW;
+  const iy = (tx + ty) * halfH;
+  ctx.save();
+  ctx.translate(originX + ix, originY + iy);
+  ctx.fillStyle = 'rgba(0, 0, 0, 0.35)';
+  ctx.beginPath();
+  ctx.ellipse(0, 10, 18, 8, 0, 0, Math.PI * 2);
+  ctx.fill();
+
+  ctx.fillStyle = '#1b2a3f';
+  ctx.strokeStyle = '#91d8ff';
+  ctx.lineWidth = 2.4;
+  ctx.beginPath();
+  ctx.moveTo(0, -14);
+  ctx.lineTo(12, 8);
+  ctx.quadraticCurveTo(0, 16, -12, 8);
+  ctx.closePath();
+  ctx.fill();
+  ctx.stroke();
+
+  ctx.fillStyle = '#2f4d6a';
+  ctx.beginPath();
+  ctx.roundRect(-8, -6, 16, 10, 3);
+  ctx.fill();
+
+  ctx.fillStyle = '#c3f2ff';
+  ctx.beginPath();
+  ctx.roundRect(-5, -4, 10, 6, 2);
+  ctx.fill();
+
+  ctx.strokeStyle = '#63fce0';
+  ctx.lineWidth = 1.6;
+  ctx.beginPath();
+  ctx.moveTo(0, -10);
+  ctx.lineTo(0, -16);
+  ctx.moveTo(-3, -9);
+  ctx.lineTo(-5, -14);
+  ctx.moveTo(3, -9);
+  ctx.lineTo(5, -14);
+  ctx.stroke();
+  ctx.restore();
+}
+
 export function drawAlienMonstrosity(
   ctx: CanvasRenderingContext2D,
   iso: IsoParams,


### PR DESCRIPTION
## Summary
- introduce reusable scenario configuration plumbing in `main.ts` and hook up the new ocean mission data
- add speedboat enemies with dedicated component, behaviour system and rendering so waves can threaten shoreline objectives
- create the Operation Stormbreak mission JSON including objectives, enemy placements and carrier launch pad to extend the campaign

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d08829d0408327a03044f44540186b