### PR TITLE
Ensure mission progress resets on reload

### DIFF
--- a/src/core/util/storage.ts
+++ b/src/core/util/storage.ts
@@ -15,3 +15,11 @@ export function saveJson<T>(key: string, value: T): void {
     // ignore
   }
 }
+
+export function removeKey(key: string): void {
+  try {
+    localStorage.removeItem(key);
+  } catch {
+    // ignore
+  }
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -58,7 +58,7 @@ import type { Building } from './game/components/Building';
 import type { Pickup } from './game/components/Pickup';
 import type { Speedboat } from './game/components/Speedboat';
 import { drawHUD } from './ui/hud/hud';
-import { loadJson, saveJson } from './core/util/storage';
+import { loadJson, saveJson, removeKey } from './core/util/storage';
 import { loadBindings, isDown } from './ui/input-remap/bindings';
 import { AudioBus } from './core/audio/audio';
 import {
@@ -301,12 +301,14 @@ interface MissionProgressData {
 
 const missionDefs: MissionDef[] = [missionJson as MissionDef, oceanMissionJson as MissionDef];
 
+removeKey('choppa:progress');
+
 function findMissionIndex(id?: string): number {
   if (!id) return -1;
   return missionDefs.findIndex((def) => def.id === id);
 }
 
-const savedProgress = loadJson<MissionProgressData>('choppa:progress', {});
+const savedProgress: MissionProgressData = {};
 let currentMissionIndex = findMissionIndex(savedProgress.current);
 if (currentMissionIndex < 0) {
   currentMissionIndex = findMissionIndex(savedProgress.mission);
@@ -330,7 +332,7 @@ const missionProgress: MissionProgressData = {
 };
 
 function persistMissionProgress(): void {
-  saveJson('choppa:progress', missionProgress);
+  removeKey('choppa:progress');
 }
 
 let missionDef: MissionDef = missionDefs[currentMissionIndex];


### PR DESCRIPTION
## Summary
- clear any saved mission progress when the game boots so reloads always start fresh
- keep mission progress in memory only by preventing persistence to localStorage while leaving other settings untouched

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d0a3cfc4e083278b63f598caa52e9e