### PR TITLE
Refactor main composition into modular bootstrap

### DIFF
--- a/src/game/app/bootstrap.ts
+++ b/src/game/app/bootstrap.ts
@@ -1,0 +1,312 @@
+import { InputManager } from '../../core/input/input';
+import { DebugOverlay } from '../../render/debug/overlay';
+import { IsoTilemapRenderer } from '../../render/draw/tilemap';
+import { Camera2D } from '../../render/camera/camera';
+import { ParallaxSky } from '../../render/draw/parallax';
+import { Menu } from '../../ui/menus/menu';
+import { createUIStore, type UIStore } from '../../ui/menus/scenes';
+import { FogOfWar } from '../../render/draw/fog';
+import { AudioBus } from '../../core/audio/audio';
+import { EngineSound } from '../../core/audio/sfx';
+import { CameraShake } from '../../render/camera/shake';
+import { EntityRegistry, type Entity } from '../../core/ecs/entities';
+import { ComponentStore } from '../../core/ecs/components';
+import type { Transform } from '../components/Transform';
+import type { Physics } from '../components/Physics';
+import type { Fuel } from '../components/Fuel';
+import type { Sprite } from '../components/Sprite';
+import type { Ammo } from '../components/Ammo';
+import type { WeaponHolder } from '../components/Weapon';
+import type { AAA, SAM, PatrolDrone, ChaserDrone } from '../components/AI';
+import type { Health } from '../components/Health';
+import type { Collider } from '../components/Collider';
+import type { Building } from '../components/Building';
+import type { Pickup } from '../components/Pickup';
+import type { Speedboat } from '../components/Speedboat';
+import { SystemScheduler } from '../../core/ecs/systems';
+import { MovementSystem } from '../systems/Movement';
+import { RotorSpinSystem } from '../systems/RotorSpin';
+import { FuelDrainSystem } from '../systems/FuelDrain';
+import { WeaponFireSystem, type FireEvent } from '../systems/WeaponFire';
+import { RNG } from '../../core/util/rng';
+import { ProjectilePool } from '../systems/Projectile';
+import { AIControlSystem } from '../systems/AIControl';
+import { EnemyBehaviorSystem } from '../systems/EnemyBehavior';
+import { SpeedboatBehaviorSystem } from '../systems/SpeedboatBehavior';
+import { DamageSystem } from '../systems/Damage';
+import { loadJson } from '../../core/util/storage';
+import { loadBindings, type KeyBindings } from '../../ui/input-remap/bindings';
+
+export interface BootstrapResult {
+  canvas: HTMLCanvasElement;
+  context: CanvasRenderingContext2D;
+  resizeCanvasToDisplaySize: () => void;
+  input: InputManager;
+  debug: DebugOverlay;
+  ui: UIStore;
+  titleMenu: Menu;
+  bindings: KeyBindings;
+  renderer: IsoTilemapRenderer;
+  camera: Camera2D;
+  sky: ParallaxSky;
+  fog: FogOfWar;
+  audio: {
+    bus: AudioBus;
+    engine: EngineSound;
+    applySettings: (muted: boolean) => void;
+  };
+  shake: CameraShake;
+  entities: EntityRegistry;
+  stores: {
+    transforms: ComponentStore<Transform>;
+    physics: ComponentStore<Physics>;
+    fuels: ComponentStore<Fuel>;
+    sprites: ComponentStore<Sprite>;
+    ammos: ComponentStore<Ammo>;
+    weapons: ComponentStore<WeaponHolder>;
+    aaas: ComponentStore<AAA>;
+    sams: ComponentStore<SAM>;
+    patrols: ComponentStore<PatrolDrone>;
+    chasers: ComponentStore<ChaserDrone>;
+    healths: ComponentStore<Health>;
+    colliders: ComponentStore<Collider>;
+    buildings: ComponentStore<Building>;
+    pickups: ComponentStore<Pickup>;
+    speedboats: ComponentStore<Speedboat>;
+  };
+  scheduler: SystemScheduler;
+  rng: RNG;
+  projectilePool: ProjectilePool;
+  fireEvents: FireEvent[];
+  weaponFire: WeaponFireSystem;
+  damage: DamageSystem;
+  setPlayerLocator: (fn: () => { x: number; y: number }) => void;
+  setBoatLandingHandler: (fn: (entity: Entity) => void) => void;
+}
+
+function setupCanvas(): {
+  canvas: HTMLCanvasElement;
+  context: CanvasRenderingContext2D;
+  resizeCanvasToDisplaySize: () => void;
+} {
+  const canvas = document.getElementById('game') as HTMLCanvasElement | null;
+  if (!canvas) throw new Error('Canvas element with id "game" not found');
+  const context = canvas.getContext('2d');
+  if (!context) throw new Error('Failed to get 2D context');
+
+  canvas.addEventListener('contextmenu', (e) => {
+    e.preventDefault();
+  });
+
+  function resizeCanvasToDisplaySize(): void {
+    const dpr = Math.max(1, window.devicePixelRatio || 1);
+    const displayWidth = Math.floor(canvas.clientWidth * dpr);
+    const displayHeight = Math.floor(canvas.clientHeight * dpr);
+    if (canvas.width !== displayWidth || canvas.height !== displayHeight) {
+      canvas.width = displayWidth;
+      canvas.height = displayHeight;
+    }
+    context.setTransform(dpr, 0, 0, dpr, 0, 0);
+  }
+
+  window.addEventListener('resize', resizeCanvasToDisplaySize);
+  resizeCanvasToDisplaySize();
+
+  return { canvas, context, resizeCanvasToDisplaySize };
+}
+
+function setupInput(): { input: InputManager; bindings: KeyBindings } {
+  const input = new InputManager();
+  input.attach(window);
+  const bindings = loadBindings();
+  return { input, bindings };
+}
+
+function setupDebug(): DebugOverlay {
+  const debug = new DebugOverlay();
+  window.addEventListener('keydown', (e) => {
+    if (e.key === '`' || e.key === '~') debug.toggle();
+  });
+  return debug;
+}
+
+function setupUI(): { ui: UIStore; titleMenu: Menu } {
+  const ui: UIStore = loadJson<UIStore>('choppa:ui', createUIStore());
+  ui.state = 'title';
+  const titleMenu = new Menu([
+    { id: 'start', label: 'Start Mission' },
+    { id: 'settings', label: 'Settings' },
+    { id: 'achievements', label: 'Achievements' },
+    { id: 'about', label: 'About' },
+  ]);
+  return { ui, titleMenu };
+}
+
+function setupAudio(ui: UIStore): {
+  bus: AudioBus;
+  engine: EngineSound;
+  applySettings: (muted: boolean) => void;
+} {
+  const bus = new AudioBus({
+    masterVolume: ui.settings.masterVolume,
+    musicVolume: ui.settings.musicVolume,
+    sfxVolume: ui.settings.sfxVolume,
+  });
+  const engine = new EngineSound(bus);
+  const applySettings = (muted: boolean): void => {
+    bus.setMaster(muted ? 0 : ui.settings.masterVolume);
+    bus.setMusic(ui.settings.musicVolume);
+    bus.setSfx(ui.settings.sfxVolume);
+  };
+  applySettings(false);
+  return { bus, engine, applySettings };
+}
+
+function setupEcs(): {
+  entities: EntityRegistry;
+  stores: BootstrapResult['stores'];
+} {
+  const entities = new EntityRegistry();
+  const stores = {
+    transforms: new ComponentStore<Transform>(),
+    physics: new ComponentStore<Physics>(),
+    fuels: new ComponentStore<Fuel>(),
+    sprites: new ComponentStore<Sprite>(),
+    ammos: new ComponentStore<Ammo>(),
+    weapons: new ComponentStore<WeaponHolder>(),
+    aaas: new ComponentStore<AAA>(),
+    sams: new ComponentStore<SAM>(),
+    patrols: new ComponentStore<PatrolDrone>(),
+    chasers: new ComponentStore<ChaserDrone>(),
+    healths: new ComponentStore<Health>(),
+    colliders: new ComponentStore<Collider>(),
+    buildings: new ComponentStore<Building>(),
+    pickups: new ComponentStore<Pickup>(),
+    speedboats: new ComponentStore<Speedboat>(),
+  };
+  return { entities, stores };
+}
+
+function setupSystems(
+  stores: BootstrapResult['stores'],
+  rng: RNG,
+): {
+  scheduler: SystemScheduler;
+  projectilePool: ProjectilePool;
+  fireEvents: FireEvent[];
+  weaponFire: WeaponFireSystem;
+  damage: DamageSystem;
+  setPlayerLocator: (fn: () => { x: number; y: number }) => void;
+  setBoatLandingHandler: (fn: (entity: Entity) => void) => void;
+} {
+  const scheduler = new SystemScheduler();
+  const projectilePool = new ProjectilePool();
+  const fireEvents: FireEvent[] = [];
+  const weaponFire = new WeaponFireSystem(
+    stores.transforms,
+    stores.physics,
+    stores.weapons,
+    stores.ammos,
+    fireEvents,
+    rng,
+  );
+  const damage = new DamageSystem(stores.transforms, stores.colliders, stores.healths);
+  scheduler.add(new MovementSystem(stores.transforms, stores.physics));
+  scheduler.add(new RotorSpinSystem(stores.sprites));
+  scheduler.add(new FuelDrainSystem(stores.fuels));
+  scheduler.add(weaponFire);
+
+  let playerLocator: () => { x: number; y: number } = () => ({ x: 0, y: 0 });
+  let boatLanding: (entity: Entity) => void = () => {};
+
+  const aiControl = new AIControlSystem(
+    stores.transforms,
+    stores.aaas,
+    stores.sams,
+    fireEvents,
+    rng,
+    () => playerLocator(),
+  );
+  const enemyBehavior = new EnemyBehaviorSystem(
+    stores.transforms,
+    stores.physics,
+    stores.patrols,
+    stores.chasers,
+    fireEvents,
+    rng,
+    () => playerLocator(),
+  );
+  const boatBehavior = new SpeedboatBehaviorSystem(
+    stores.transforms,
+    stores.physics,
+    stores.speedboats,
+    fireEvents,
+    rng,
+    () => playerLocator(),
+    (entity) => boatLanding(entity),
+  );
+
+  scheduler.add(aiControl);
+  scheduler.add(enemyBehavior);
+  scheduler.add(boatBehavior);
+
+  const setPlayerLocator = (fn: () => { x: number; y: number }): void => {
+    playerLocator = fn;
+  };
+  const setBoatLandingHandler = (fn: (entity: Entity) => void): void => {
+    boatLanding = fn;
+  };
+
+  return {
+    scheduler,
+    projectilePool,
+    fireEvents,
+    weaponFire,
+    damage,
+    setPlayerLocator,
+    setBoatLandingHandler,
+  };
+}
+
+export function bootstrapApp(): BootstrapResult {
+  const { canvas, context, resizeCanvasToDisplaySize } = setupCanvas();
+  const { input, bindings } = setupInput();
+  const debug = setupDebug();
+  const { ui, titleMenu } = setupUI();
+  const audio = setupAudio(ui);
+  const renderer = new IsoTilemapRenderer();
+  const camera = new Camera2D({ deadzoneWidth: 160, deadzoneHeight: 120, lerp: 0.12 });
+  const sky = new ParallaxSky();
+  const fog = new FogOfWar();
+  const shake = new CameraShake();
+  const { entities, stores } = setupEcs();
+  const rng = new RNG(1337);
+  const systems = setupSystems(stores, rng);
+
+  return {
+    canvas,
+    context,
+    resizeCanvasToDisplaySize,
+    input,
+    debug,
+    ui,
+    titleMenu,
+    bindings,
+    renderer,
+    camera,
+    sky,
+    fog,
+    audio,
+    shake,
+    entities,
+    stores,
+    scheduler: systems.scheduler,
+    rng,
+    projectilePool: systems.projectilePool,
+    fireEvents: systems.fireEvents,
+    weaponFire: systems.weaponFire,
+    damage: systems.damage,
+    setPlayerLocator: systems.setPlayerLocator,
+    setBoatLandingHandler: systems.setBoatLandingHandler,
+  };
+}

--- a/src/game/app/state.ts
+++ b/src/game/app/state.ts
@@ -1,0 +1,120 @@
+import type { Entity } from '../../core/ecs/entities';
+import type { Pickup } from '../components/Pickup';
+import type { PickupCraneSoundHandle } from '../../core/audio/sfx';
+import type { BoatScenarioConfig } from '../missions/coordinator';
+
+export interface EnemyMeta {
+  kind: 'aaa' | 'sam' | 'patrol' | 'chaser' | 'speedboat';
+  score: number;
+  wave?: number;
+}
+
+export interface BuildingMeta {
+  score: number;
+  drop?: { kind: 'armor'; amount: number };
+  category: 'campus' | 'stronghold' | 'civilian';
+  triggersAlarm: boolean;
+}
+
+export interface Explosion {
+  tx: number;
+  ty: number;
+  age: number;
+  duration: number;
+  radius: number;
+}
+
+export interface RescueRunner {
+  startIso: { x: number; y: number };
+  endIso: { x: number; y: number };
+  progress: number;
+  delay: number;
+  duration: number;
+  elapsed: number;
+  bobOffset: number;
+}
+
+export interface WaveState {
+  index: number;
+  countdown: number;
+  active: boolean;
+  timeInWave: number;
+  enemies: Set<Entity>;
+}
+
+export interface PlayerState {
+  lives: number;
+  respawnTimer: number;
+  invulnerable: boolean;
+}
+
+export interface RescueState {
+  carrying: number;
+  rescued: number;
+  total: number;
+  survivorsSpawned: boolean;
+}
+
+export interface BoatState {
+  scenario: BoatScenarioConfig | null;
+  boatsEscaped: number;
+  objectiveComplete: boolean;
+  objectiveFailed: boolean;
+}
+
+export interface PickupCompleteEvent {
+  entity: Entity;
+  kind: Pickup['kind'];
+  fuelAmount?: number;
+  ammo?: { missiles?: number; rockets?: number; hellfires?: number };
+  survivorCount?: number;
+  armorAmount?: number;
+}
+
+export const SURVIVOR_CAPACITY = 4;
+
+export interface GameState {
+  playerId: Entity | null;
+  player: PlayerState;
+  stats: { score: number };
+  explosions: Explosion[];
+  enemyMeta: Map<Entity, EnemyMeta>;
+  buildingMeta: Map<Entity, BuildingMeta>;
+  wave: WaveState;
+  minimapEnemies: { tx: number; ty: number }[];
+  buildingEntities: Entity[];
+  pickupEntities: Entity[];
+  pickupCraneSounds: Map<Entity, PickupCraneSoundHandle>;
+  survivorEntities: Entity[];
+  alienEntities: Set<Entity>;
+  rescueRunners: RescueRunner[];
+  rescue: RescueState;
+  flags: {
+    aliensTriggered: boolean;
+    aliensDefeated: boolean;
+    campusLeveled: boolean;
+  };
+  boat: BoatState;
+}
+
+export function createGameState(): GameState {
+  return {
+    playerId: null,
+    player: { lives: 3, respawnTimer: 0, invulnerable: false },
+    stats: { score: 0 },
+    explosions: [],
+    enemyMeta: new Map(),
+    buildingMeta: new Map(),
+    wave: { index: 0, countdown: 3, active: false, timeInWave: 0, enemies: new Set() },
+    minimapEnemies: [],
+    buildingEntities: [],
+    pickupEntities: [],
+    pickupCraneSounds: new Map(),
+    survivorEntities: [],
+    alienEntities: new Set(),
+    rescueRunners: [],
+    rescue: { carrying: 0, rescued: 0, total: 0, survivorsSpawned: false },
+    flags: { aliensTriggered: false, aliensDefeated: false, campusLeveled: false },
+    boat: { scenario: null, boatsEscaped: 0, objectiveComplete: false, objectiveFailed: false },
+  };
+}

--- a/src/game/app/update/combat.ts
+++ b/src/game/app/update/combat.ts
@@ -1,0 +1,342 @@
+import type { ComponentStore } from '../../../core/ecs/components';
+import type { Entity } from '../../../core/ecs/entities';
+import type { Transform } from '../../components/Transform';
+import type { Collider } from '../../components/Collider';
+import type { Health } from '../../components/Health';
+import type { Physics } from '../../components/Physics';
+import type { Building } from '../../components/Building';
+import type { GameState } from '../state';
+import {
+  playMissile,
+  playRocket,
+  playHellfire,
+  playExplosion,
+  type EngineSound,
+} from '../../../core/audio/sfx';
+import type { AudioBus } from '../../../core/audio/audio';
+import type { CameraShake } from '../../../render/camera/shake';
+import type { SystemScheduler } from '../../../core/ecs/systems';
+import type { ProjectilePool } from '../../systems/Projectile';
+import type { DamageSystem } from '../../systems/Damage';
+import type { FireEvent } from '../../systems/WeaponFire';
+import type { MissionTracker } from '../../missions/tracker';
+import type { MissionCoordinator } from '../../missions/coordinator';
+import type { SurvivorSite } from '../../scenarios/layouts';
+import type { UIStore } from '../../../ui/menus/scenes';
+
+export interface CombatProcessorDeps {
+  state: GameState;
+  ui: UIStore;
+  player: Entity;
+  scheduler: SystemScheduler;
+  fireEvents: FireEvent[];
+  projectilePool: ProjectilePool;
+  damage: DamageSystem;
+  bus: AudioBus;
+  shake: CameraShake;
+  transforms: ComponentStore<Transform>;
+  colliders: ComponentStore<Collider>;
+  physics: ComponentStore<Physics>;
+  healths: ComponentStore<Health>;
+  buildings: ComponentStore<Building>;
+  mission: MissionTracker;
+  missionCoordinator: MissionCoordinator;
+  spawnSurvivors: (sites: SurvivorSite[]) => void;
+  spawnPickupDrop: (tx: number, ty: number, amount: number) => void;
+  destroyEntity: (entity: Entity) => void;
+  engine: EngineSound;
+  spawnAlienUnit: (point: { tx: number; ty: number }) => void;
+}
+
+export interface CombatProcessor {
+  update: (dt: number) => void;
+  handleBoatLanding: (entity: Entity) => void;
+  spawnExplosion: (tx: number, ty: number, radius?: number, duration?: number) => void;
+}
+
+export function createCombatProcessor({
+  state,
+  ui,
+  player,
+  scheduler,
+  fireEvents,
+  projectilePool,
+  damage,
+  bus,
+  shake,
+  transforms,
+  colliders,
+  physics,
+  healths,
+  buildings,
+  mission,
+  missionCoordinator,
+  spawnSurvivors,
+  spawnPickupDrop,
+  destroyEntity,
+  engine,
+  spawnAlienUnit,
+}: CombatProcessorDeps): CombatProcessor {
+  const spawnExplosion = (tx: number, ty: number, radius = 0.9, duration = 0.6): void => {
+    state.explosions.push({ tx, ty, age: 0, duration, radius });
+  };
+
+  const updateExplosions = (dt: number): void => {
+    for (let i = state.explosions.length - 1; i >= 0; i -= 1) {
+      const e = state.explosions[i]!;
+      e.age += dt;
+      if (e.age >= e.duration) state.explosions.splice(i, 1);
+    }
+  };
+
+  const handleBoatLanding = (entity: Entity): void => {
+    const t = transforms.get(entity);
+    if (t) spawnExplosion(t.tx, t.ty, 1.1, 0.8);
+    playExplosion(bus, 0.8);
+    destroyEntity(entity);
+    state.boat.boatsEscaped += 1;
+    const boatScenario = state.boat.scenario;
+    if (
+      ui.state === 'in-game' &&
+      boatScenario &&
+      state.boat.boatsEscaped >= boatScenario.maxEscapes
+    ) {
+      state.boat.objectiveFailed = true;
+      ui.state = 'game-over';
+      state.wave.active = false;
+      engine.stop();
+    }
+  };
+
+  const triggerAlienCounterattack = (): void => {
+    if (state.flags.aliensTriggered) return;
+    state.flags.aliensTriggered = true;
+    state.flags.aliensDefeated = false;
+    const scenario = missionCoordinator.getScenario();
+    for (let i = 0; i < scenario.alienSpawnPoints.length; i += 1) {
+      spawnAlienUnit(scenario.alienSpawnPoints[i]!);
+    }
+  };
+
+  const checkBuildingsForAlienTrigger = (): void => {
+    if (state.flags.aliensTriggered) return;
+    for (let i = 0; i < state.buildingEntities.length; i += 1) {
+      const entity = state.buildingEntities[i]!;
+      const meta = state.buildingMeta.get(entity);
+      if (!meta || !meta.triggersAlarm) continue;
+      const health = healths.get(entity);
+      if (health && health.current < health.max) {
+        triggerAlienCounterattack();
+        break;
+      }
+    }
+  };
+
+  const handlePlayerDeath = (): void => {
+    const t = transforms.get(player);
+    if (t) spawnExplosion(t.tx, t.ty);
+    playExplosion(bus);
+    colliders.remove(player);
+    const body = physics.get(player);
+    if (body) {
+      body.vx = 0;
+      body.vy = 0;
+      body.ax = 0;
+      body.ay = 0;
+    }
+    state.player.lives -= 1;
+    state.player.invulnerable = true;
+    state.player.respawnTimer = 2.5;
+    if (state.player.lives <= 0) {
+      ui.state = 'game-over';
+      state.wave.active = false;
+      engine.stop();
+    }
+  };
+
+  const handleDeaths = (): void => {
+    const deaths = damage.consumeDeaths();
+    for (let i = 0; i < deaths.length; i += 1) {
+      const entity = deaths[i]!;
+      if (entity === player) {
+        handlePlayerDeath();
+        continue;
+      }
+      const enemyMeta = state.enemyMeta.get(entity);
+      if (enemyMeta) {
+        const t = transforms.get(entity);
+        if (t) spawnExplosion(t.tx, t.ty);
+        playExplosion(bus);
+        state.stats.score += enemyMeta.score;
+        destroyEntity(entity);
+        continue;
+      }
+      const buildingComp = buildings.get(entity);
+      if (buildingComp) {
+        const t = transforms.get(entity);
+        if (t) spawnExplosion(t.tx, t.ty);
+        playExplosion(bus);
+        const meta = state.buildingMeta.get(entity);
+        if (meta) {
+          if (meta.score) state.stats.score += meta.score;
+          if (t && meta.drop) {
+            spawnPickupDrop(t.tx, t.ty, meta.drop.amount);
+          }
+        }
+        destroyEntity(entity);
+        continue;
+      }
+      destroyEntity(entity);
+    }
+  };
+
+  const updateWave = (dt: number): void => {
+    if (ui.state !== 'in-game') return;
+    const scenario = missionCoordinator.getScenario();
+    if (state.wave.active) {
+      state.wave.timeInWave += dt;
+      if (state.wave.enemies.size === 0) {
+        state.wave.active = false;
+        const cooldown = scenario.waveCooldown
+          ? scenario.waveCooldown(state.wave.index)
+          : Number.POSITIVE_INFINITY;
+        state.wave.countdown = cooldown;
+        if (
+          scenario.boatScenario &&
+          state.wave.index >= scenario.boatScenario.waves.length &&
+          !state.boat.objectiveFailed
+        ) {
+          state.boat.objectiveComplete = true;
+        }
+      }
+    } else if (scenario.waveSpawner) {
+      if (!Number.isFinite(state.wave.countdown)) return;
+      state.wave.countdown -= dt;
+      if (state.wave.countdown <= 0) {
+        state.wave.index += 1;
+        const spawned = scenario.waveSpawner(state.wave.index);
+        if (spawned) {
+          state.wave.active = true;
+          state.wave.timeInWave = 0;
+        } else {
+          state.wave.countdown = Number.POSITIVE_INFINITY;
+        }
+      }
+    }
+  };
+
+  const update = (dt: number): void => {
+    const scenario = missionCoordinator.getScenario();
+    scheduler.update(dt);
+
+    for (let i = 0; i < fireEvents.length; i += 1) {
+      const ev = fireEvents[i]!;
+      if (ev.kind === 'missile') {
+        playMissile(bus);
+        const dirLen = Math.hypot(ev.dx, ev.dy) || 1;
+        const dirX = ev.dx / dirLen;
+        const dirY = ev.dy / dirLen;
+        const speedM = ev.speed ?? 22;
+        const launchOffset = ev.launchOffset ?? 0.48;
+        const spawnX = ev.sx + dirX * launchOffset;
+        const spawnY = ev.sy + dirY * launchOffset;
+        projectilePool.spawn({
+          kind: 'missile',
+          faction: ev.faction,
+          x: spawnX,
+          y: spawnY,
+          vx: dirX * speedM,
+          vy: dirY * speedM,
+          ttl: ev.ttl ?? 0.6,
+          radius: ev.radius ?? 0.08,
+          damage: { amount: ev.damage ?? 10, radius: ev.damageRadius ?? 0.12 },
+        });
+      } else if (ev.kind === 'rocket') {
+        playRocket(bus);
+        projectilePool.spawn({
+          kind: 'rocket',
+          faction: ev.faction,
+          x: ev.x,
+          y: ev.y,
+          vx: ev.vx,
+          vy: ev.vy,
+          ttl: ev.ttl ?? 5.2,
+          radius: ev.radius ?? 0.22,
+          damage: { amount: ev.damage ?? 16, radius: ev.damageRadius ?? 0.9 },
+        });
+      } else if (ev.kind === 'hellfire') {
+        playHellfire(bus);
+        const velLen = Math.hypot(ev.vx, ev.vy) || 1;
+        const dirX = ev.vx / velLen;
+        const dirY = ev.vy / velLen;
+        const launchOffset = ev.launchOffset ?? 0.92;
+        const speedH = ev.speed ?? velLen;
+        const spawnX = ev.x + dirX * launchOffset;
+        const spawnY = ev.y + dirY * launchOffset;
+        projectilePool.spawn({
+          kind: 'hellfire',
+          faction: ev.faction,
+          x: spawnX,
+          y: spawnY,
+          vx: dirX * speedH,
+          vy: dirY * speedH,
+          ttl: ev.ttl ?? 3.2,
+          radius: ev.radius ?? 0.3,
+          seek: { targetX: ev.targetX, targetY: ev.targetY, turnRate: Math.PI * 0.8 },
+          damage: { amount: ev.damage ?? 36, radius: ev.damageRadius ?? 1.9 },
+        });
+      }
+    }
+    fireEvents.length = 0;
+
+    projectilePool.update(dt, colliders, colliders, transforms, (hit) => {
+      damage.queue(hit);
+      const boomRadius = Math.max(0.2, hit.radius * 1.45);
+      const boomDuration = 0.32 + hit.radius * 0.38;
+      spawnExplosion(hit.x, hit.y, boomRadius, boomDuration);
+      playExplosion(bus, hit.radius);
+      if (ui.settings.screenShake) shake.trigger(8, 0.25);
+    });
+
+    damage.update();
+    checkBuildingsForAlienTrigger();
+    handleDeaths();
+
+    if (!state.flags.campusLeveled) {
+      let campusRemaining = 0;
+      state.buildingMeta.forEach((meta) => {
+        if (meta.category === 'campus') campusRemaining += 1;
+      });
+      if (campusRemaining === 0) state.flags.campusLeveled = true;
+    }
+
+    if (
+      state.flags.aliensTriggered &&
+      !state.flags.aliensDefeated &&
+      state.alienEntities.size === 0
+    ) {
+      state.flags.aliensDefeated = true;
+    }
+
+    if (!state.rescue.survivorsSpawned && state.flags.campusLeveled && state.flags.aliensDefeated) {
+      spawnSurvivors(scenario.survivorSites);
+      state.rescue.survivorsSpawned = true;
+      state.rescue.total = scenario.survivorSites.reduce((sum, site) => sum + site.count, 0);
+    }
+
+    mission.update();
+    if (mission.state.complete && ui.state === 'in-game') {
+      ui.state = 'win';
+      missionCoordinator.onMissionWin();
+    }
+
+    updateWave(dt);
+    updateExplosions(dt);
+  };
+
+  return {
+    update,
+    handleBoatLanding,
+    spawnExplosion,
+  };
+}

--- a/src/game/app/update/pickups.ts
+++ b/src/game/app/update/pickups.ts
@@ -1,0 +1,257 @@
+import type { ComponentStore } from '../../../core/ecs/components';
+import type { Entity } from '../../../core/ecs/entities';
+import type { Transform } from '../../components/Transform';
+import type { Pickup } from '../../components/Pickup';
+import type { Fuel } from '../../components/Fuel';
+import type { Ammo } from '../../components/Ammo';
+import type { Health } from '../../components/Health';
+import type { GameState } from '../state';
+import { SURVIVOR_CAPACITY } from '../state';
+import type { PickupCompleteEvent } from '../state';
+import type { PadConfig } from '../../scenarios/layouts';
+import type { SafeHouseParams } from '../../../render/sprites/safehouse';
+import { tileToIso } from '../../../render/iso/projection';
+import { getSafeHouseDoorIso } from '../../../render/sprites/safehouse';
+import type { RNG } from '../../../core/util/rng';
+
+export interface PickupProcessorDeps {
+  state: GameState;
+  player: Entity;
+  transforms: ComponentStore<Transform>;
+  pickups: ComponentStore<Pickup>;
+  fuels: ComponentStore<Fuel>;
+  ammos: ComponentStore<Ammo>;
+  healths: ComponentStore<Health>;
+  pickupFactory: {
+    beginPickupCraneSound: (entity: Entity, pickup: Pickup) => void;
+    cancelPickupCraneSound: (entity: Entity) => void;
+    completePickupCraneSound: (entity: Entity) => void;
+  };
+  destroyEntity: (entity: Entity) => void;
+  rng: RNG;
+}
+
+export interface PickupProcessor {
+  update: (
+    dt: number,
+    isoParams: { tileWidth: number; tileHeight: number },
+    pad: PadConfig,
+    safeHouse: SafeHouseParams,
+  ) => void;
+  spawnRescueRunnerAnimation: (
+    count: number,
+    isoParams: { tileWidth: number; tileHeight: number },
+    pad: PadConfig,
+    safeHouse: SafeHouseParams,
+  ) => void;
+  updateRescueRunners: (dt: number) => void;
+}
+
+export function createPickupProcessor({
+  state,
+  player,
+  transforms,
+  pickups,
+  fuels,
+  ammos,
+  healths,
+  pickupFactory,
+  destroyEntity,
+  rng,
+}: PickupProcessorDeps): PickupProcessor {
+  const spawnRescueRunnerAnimation = (
+    count: number,
+    isoParams: { tileWidth: number; tileHeight: number },
+    pad: PadConfig,
+    safeHouse: SafeHouseParams,
+  ): void => {
+    if (count <= 0) return;
+    const padOrigin = tileToIso(pad.tx - 0.05, pad.ty + 0.18, isoParams);
+    const doorIso = getSafeHouseDoorIso(isoParams, safeHouse);
+    for (let i = 0; i < count; i += 1) {
+      const jitterStartX = (rng.float01() - 0.5) * 10;
+      const jitterStartY = (rng.float01() - 0.5) * 6;
+      const jitterEndX = (rng.float01() - 0.5) * 3;
+      const jitterEndY = (rng.float01() - 0.5) * 2.4;
+      const delay = i * 0.16 + rng.float01() * 0.05;
+      const duration = 0.82 + rng.float01() * 0.32;
+      state.rescueRunners.push({
+        startIso: { x: padOrigin.x + jitterStartX, y: padOrigin.y + jitterStartY },
+        endIso: { x: doorIso.x + jitterEndX, y: doorIso.y + jitterEndY },
+        progress: 0,
+        delay,
+        duration,
+        elapsed: 0,
+        bobOffset: rng.float01() * Math.PI * 2,
+      });
+    }
+  };
+
+  const updateRescueRunners = (dt: number): void => {
+    for (let i = state.rescueRunners.length - 1; i >= 0; i -= 1) {
+      const runner = state.rescueRunners[i]!;
+      if (runner.delay > 0) {
+        runner.delay -= dt;
+        if (runner.delay > 0) continue;
+        runner.delay = 0;
+      }
+      runner.elapsed += dt;
+      runner.progress += dt / runner.duration;
+      if (runner.progress >= 1.3) {
+        state.rescueRunners.splice(i, 1);
+      }
+    }
+  };
+
+  const update = (
+    dt: number,
+    isoParams: { tileWidth: number; tileHeight: number },
+    pad: PadConfig,
+    safeHouse: SafeHouseParams,
+  ): void => {
+    const completed: PickupCompleteEvent[] = [];
+    pickups.forEach((entity, pickup) => {
+      const pickupTransform = transforms.get(entity);
+      if (!pickupTransform) {
+        pickupFactory.completePickupCraneSound(entity);
+        completed.push({
+          entity,
+          kind: pickup.kind,
+          fuelAmount: pickup.fuelAmount,
+          ammo: pickup.ammo ? { ...pickup.ammo } : undefined,
+          survivorCount: pickup.survivorCount,
+          armorAmount: pickup.armorAmount,
+        });
+        return;
+      }
+
+      if (pickup.collectingBy === player) {
+        const playerTransform = transforms.get(player)!;
+        const dx = pickupTransform.tx - playerTransform.tx;
+        const dy = pickupTransform.ty - playerTransform.ty;
+        const dist = Math.hypot(dx, dy);
+        if (dist > pickup.radius + 0.4 || state.player.invulnerable) {
+          pickup.collectingBy = null;
+          pickup.progress = 0;
+          pickupFactory.cancelPickupCraneSound(entity);
+          return;
+        }
+        pickup.progress = Math.min(1, pickup.progress + dt / pickup.duration);
+        if (pickup.progress >= 1) {
+          pickupFactory.completePickupCraneSound(entity);
+          completed.push({
+            entity,
+            kind: pickup.kind,
+            fuelAmount: pickup.fuelAmount,
+            ammo: pickup.ammo ? { ...pickup.ammo } : undefined,
+            survivorCount: pickup.survivorCount,
+            armorAmount: pickup.armorAmount,
+          });
+        }
+        return;
+      }
+
+      if (pickup.collectingBy && !transforms.has(pickup.collectingBy)) {
+        pickup.collectingBy = null;
+        pickup.progress = 0;
+        pickupFactory.cancelPickupCraneSound(entity);
+        return;
+      }
+
+      if (pickup.collectingBy === null) {
+        const playerTransform = transforms.get(player)!;
+        const dx = pickupTransform.tx - playerTransform.tx;
+        const dy = pickupTransform.ty - playerTransform.ty;
+        const dist = Math.hypot(dx, dy);
+        if (dist <= pickup.radius && !state.player.invulnerable) {
+          if (pickup.kind === 'fuel') {
+            const needsFuel = fuels.get(player)!.current < fuels.get(player)!.max - 0.5;
+            if (needsFuel) {
+              pickup.collectingBy = player;
+              pickup.progress = 0;
+              pickupFactory.beginPickupCraneSound(entity, pickup);
+            }
+          } else if (pickup.kind === 'ammo') {
+            const ammoComp = ammos.get(player)!;
+            const needsAmmo =
+              ammoComp.missiles < ammoComp.missilesMax ||
+              ammoComp.rockets < ammoComp.rocketsMax ||
+              ammoComp.hellfires < ammoComp.hellfiresMax;
+            if (needsAmmo) {
+              pickup.collectingBy = player;
+              pickup.progress = 0;
+              pickupFactory.beginPickupCraneSound(entity, pickup);
+            }
+          } else if (pickup.kind === 'survivor') {
+            const survivors = pickup.survivorCount ?? 1;
+            const remainingCapacity = SURVIVOR_CAPACITY - state.rescue.carrying;
+            if (remainingCapacity >= survivors) {
+              pickup.collectingBy = player;
+              pickup.progress = 0;
+              pickupFactory.beginPickupCraneSound(entity, pickup);
+            }
+          } else if (pickup.kind === 'armor') {
+            const needsArmor = healths.get(player)!.current < healths.get(player)!.max - 0.5;
+            if (needsArmor) {
+              pickup.collectingBy = player;
+              pickup.progress = 0;
+              pickupFactory.beginPickupCraneSound(entity, pickup);
+            }
+          }
+        }
+      }
+    });
+
+    for (let i = 0; i < completed.length; i += 1) {
+      const item = completed[i]!;
+      const fuelComp = fuels.get(player)!;
+      const ammoComp = ammos.get(player)!;
+      const healthComp = healths.get(player)!;
+      if (item.kind === 'fuel') {
+        const amount = item.fuelAmount ?? 50;
+        fuelComp.current = Math.min(fuelComp.max, fuelComp.current + amount);
+      } else if (item.kind === 'ammo' && item.ammo) {
+        ammoComp.rockets = Math.min(
+          ammoComp.rocketsMax,
+          ammoComp.rockets + (item.ammo.rockets ?? 0),
+        );
+        ammoComp.missiles = Math.min(
+          ammoComp.missilesMax,
+          ammoComp.missiles + (item.ammo.missiles ?? 0),
+        );
+        ammoComp.hellfires = Math.min(
+          ammoComp.hellfiresMax,
+          ammoComp.hellfires + (item.ammo.hellfires ?? 0),
+        );
+      } else if (item.kind === 'armor') {
+        const amount = item.armorAmount ?? 35;
+        healthComp.current = Math.min(healthComp.max, healthComp.current + amount);
+      } else if (item.kind === 'survivor') {
+        const count = item.survivorCount ?? 1;
+        state.rescue.carrying = Math.min(SURVIVOR_CAPACITY, state.rescue.carrying + count);
+      }
+      destroyEntity(item.entity);
+    }
+
+    if (state.rescue.carrying > 0 && !state.player.invulnerable) {
+      const playerTransform = transforms.get(player)!;
+      const dxPad = playerTransform.tx - pad.tx;
+      const dyPad = playerTransform.ty - pad.ty;
+      const distPad = Math.hypot(dxPad, dyPad);
+      if (distPad <= pad.radius + 0.2) {
+        const dropped = state.rescue.carrying;
+        if (dropped > 0) spawnRescueRunnerAnimation(dropped, isoParams, pad, safeHouse);
+        state.rescue.rescued = Math.min(state.rescue.total, state.rescue.rescued + dropped);
+        state.rescue.carrying = 0;
+      }
+    }
+
+    updateRescueRunners(dt);
+  };
+
+  return {
+    update,
+    spawnRescueRunnerAnimation,
+    updateRescueRunners,
+  };
+}

--- a/src/game/app/update/player.ts
+++ b/src/game/app/update/player.ts
@@ -1,0 +1,165 @@
+import type { InputSnapshot } from '../../../core/input/input';
+import { isDown, type KeyBindings } from '../../../ui/input-remap/bindings';
+import type { UIStore } from '../../../ui/menus/scenes';
+import type { GameState } from '../state';
+import type { Entity } from '../../../core/ecs/entities';
+import type { ComponentStore } from '../../../core/ecs/components';
+import type { Transform } from '../../components/Transform';
+import type { Physics } from '../../components/Physics';
+import type { Fuel } from '../../components/Fuel';
+import type { Ammo } from '../../components/Ammo';
+import type { Health } from '../../components/Health';
+import type { Collider } from '../../components/Collider';
+import type { RuntimeTilemap } from '../../../world/tiles/tiled';
+import { screenToApproxTile } from '../../../render/iso/projection';
+import { getCanvasViewMetrics } from '../../../render/canvas/metrics';
+import type { WeaponFireSystem } from '../../systems/WeaponFire';
+import type { EngineSound } from '../../../core/audio/sfx';
+import type { Camera2D } from '../../../render/camera/camera';
+
+export interface PlayerControllerDeps {
+  state: GameState;
+  ui: UIStore;
+  player: Entity;
+  transforms: ComponentStore<Transform>;
+  physics: ComponentStore<Physics>;
+  fuels: ComponentStore<Fuel>;
+  ammos: ComponentStore<Ammo>;
+  healths: ComponentStore<Health>;
+  colliders: ComponentStore<Collider>;
+  weaponFire: WeaponFireSystem;
+  engine: EngineSound;
+  bindings: KeyBindings;
+  camera: Camera2D;
+  context: CanvasRenderingContext2D;
+  getStartPosition: () => { tx: number; ty: number };
+}
+
+export interface PlayerController {
+  update: (
+    dt: number,
+    snapshot: InputSnapshot,
+    isoParams: { tileWidth: number; tileHeight: number },
+    map: RuntimeTilemap,
+  ) => void;
+  resetPlayer: () => void;
+}
+
+export function createPlayerController({
+  state,
+  ui,
+  player,
+  transforms,
+  physics,
+  fuels,
+  ammos,
+  healths,
+  colliders,
+  weaponFire,
+  engine,
+  bindings,
+  camera,
+  context,
+  getStartPosition,
+}: PlayerControllerDeps): PlayerController {
+  const tryRespawn = (dt: number): void => {
+    if (!state.player.invulnerable || ui.state === 'game-over') return;
+    state.player.respawnTimer -= dt;
+    if (state.player.respawnTimer <= 0 && state.player.lives > 0) {
+      resetPlayerInternal();
+    }
+  };
+
+  const resetPlayerInternal = (): void => {
+    const start = getStartPosition();
+    const transform = transforms.get(player);
+    const body = physics.get(player);
+    const fuel = fuels.get(player);
+    const ammo = ammos.get(player);
+    const health = healths.get(player);
+    if (transform && body && fuel && ammo && health) {
+      transform.tx = start.tx;
+      transform.ty = start.ty;
+      transform.rot = 0;
+      body.vx = 0;
+      body.vy = 0;
+      body.ax = 0;
+      body.ay = 0;
+      fuel.current = fuel.max;
+      ammo.missiles = ammo.missilesMax;
+      ammo.rockets = ammo.rocketsMax;
+      ammo.hellfires = ammo.hellfiresMax;
+      health.current = health.max;
+      colliders.set(player, { radius: 0.4, team: 'player' });
+    }
+    state.player.respawnTimer = 0;
+    state.player.invulnerable = false;
+    engine.start();
+    engine.setIntensity(0);
+  };
+
+  const update = (
+    dt: number,
+    snapshot: InputSnapshot,
+    isoParams: { tileWidth: number; tileHeight: number },
+    map: RuntimeTilemap,
+  ): void => {
+    tryRespawn(dt);
+
+    const transform = transforms.get(player)!;
+    const body = physics.get(player)!;
+    let dx = 0;
+    let dy = 0;
+    if (!state.player.invulnerable) {
+      if (isDown(snapshot, bindings, 'moveUp')) dy -= 1;
+      if (isDown(snapshot, bindings, 'moveDown')) dy += 1;
+      if (isDown(snapshot, bindings, 'moveLeft')) dx -= 1;
+      if (isDown(snapshot, bindings, 'moveRight')) dx += 1;
+      if (isDown(snapshot, bindings, 'strafeLeft')) dx -= 1;
+      if (isDown(snapshot, bindings, 'strafeRight')) dx += 1;
+    }
+    if (dx !== 0 || dy !== 0) {
+      const len = Math.hypot(dx, dy) || 1;
+      dx /= len;
+      dy /= len;
+    }
+    const accel = 12;
+    body.ax = dx * accel;
+    body.ay = dy * accel;
+
+    const speed = Math.min(1, Math.hypot(body.vx, body.vy) / (body.maxSpeed || 1));
+    engine.start();
+    engine.setIntensity(speed);
+
+    const { width: viewWidth, height: viewHeight } = getCanvasViewMetrics(context);
+    let aimTile = screenToApproxTile(
+      snapshot.mouseX,
+      snapshot.mouseY,
+      viewWidth,
+      viewHeight,
+      camera.x,
+      camera.y,
+      isoParams,
+    );
+    const aimDx = aimTile.x - transform.tx;
+    const aimDy = aimTile.y - transform.ty;
+    if (!Number.isFinite(aimDx) || !Number.isFinite(aimDy) || Math.hypot(aimDx, aimDy) < 0.3) {
+      aimTile = {
+        x: transform.tx + Math.cos(transform.rot),
+        y: transform.ty + Math.sin(transform.rot),
+      };
+    }
+    weaponFire.setInput(snapshot, aimTile.x, aimTile.y);
+
+    const margin = 1.2;
+    const maxX = map.width - 1 - margin;
+    const maxY = map.height - 1 - margin;
+    transform.tx = Math.max(margin, Math.min(maxX, transform.tx));
+    transform.ty = Math.max(margin, Math.min(maxY, transform.ty));
+  };
+
+  return {
+    update,
+    resetPlayer: resetPlayerInternal,
+  };
+}

--- a/src/game/app/update/ui.ts
+++ b/src/game/app/update/ui.ts
@@ -1,0 +1,114 @@
+import type { InputSnapshot } from '../../../core/input/input';
+import type { UIStore } from '../../../ui/menus/scenes';
+import type { Menu } from '../../../ui/menus/menu';
+import type { KeyBindings } from '../../../ui/input-remap/bindings';
+import { isDown } from '../../../ui/input-remap/bindings';
+
+export interface UIControllerDeps {
+  ui: UIStore;
+  titleMenu: Menu;
+  bindings: KeyBindings;
+  saveUI: (ui: UIStore) => void;
+  applyAudioSettings: (muted: boolean) => void;
+  resetGame: (missionIndex?: number) => void;
+  getNextMissionIndex: () => number;
+}
+
+export interface UIController {
+  update: (dt: number, snapshot: InputSnapshot) => boolean;
+  isAudioMuted: () => boolean;
+}
+
+export function createUIController({
+  ui,
+  titleMenu,
+  bindings,
+  saveUI,
+  applyAudioSettings,
+  resetGame,
+  getNextMissionIndex,
+}: UIControllerDeps): UIController {
+  let pauseLatch = false;
+  let muteLatch = false;
+  let audioMuted = false;
+
+  const update = (_dt: number, snapshot: InputSnapshot): boolean => {
+    const pauseDown = isDown(snapshot, bindings, 'pause');
+    if (pauseDown && !pauseLatch) {
+      if (ui.state === 'in-game') ui.state = 'paused';
+      else if (ui.state === 'paused') ui.state = 'in-game';
+      else if (ui.state === 'title') ui.state = 'in-game';
+    }
+    pauseLatch = pauseDown;
+
+    const muteDown = snapshot.keys['m'] || snapshot.keys['M'];
+    if (muteDown && !muteLatch) {
+      audioMuted = !audioMuted;
+      applyAudioSettings(audioMuted);
+    }
+    muteLatch = muteDown;
+
+    if (ui.state === 'title') {
+      const action = titleMenu.update(snapshot);
+      if (action === 'start') {
+        resetGame();
+      } else if (action === 'settings') ui.state = 'settings';
+      else if (action === 'achievements') ui.state = 'achievements';
+      else if (action === 'about') ui.state = 'about';
+      if (action) saveUI(ui);
+      return false;
+    }
+
+    if (ui.state === 'settings') {
+      if (snapshot.keys['Escape']) ui.state = 'title';
+      return false;
+    }
+
+    if (ui.state === 'achievements') {
+      if (snapshot.keys['Escape']) ui.state = 'title';
+      return false;
+    }
+
+    if (ui.state === 'about') {
+      if (snapshot.keys['Escape']) ui.state = 'title';
+      return false;
+    }
+
+    if (ui.state === 'briefing') {
+      if (snapshot.keys['Enter'] || snapshot.keys[' '] || snapshot.keys['Space'])
+        ui.state = 'in-game';
+      return false;
+    }
+
+    if (ui.state === 'paused') {
+      if (snapshot.keys['Escape']) ui.state = 'in-game';
+      return false;
+    }
+
+    if (ui.state === 'game-over') {
+      if (
+        snapshot.keys['Enter'] ||
+        snapshot.keys[' '] ||
+        snapshot.keys['r'] ||
+        snapshot.keys['R']
+      ) {
+        resetGame();
+      }
+      if (snapshot.keys['Escape']) ui.state = 'title';
+      return false;
+    }
+
+    if (ui.state === 'win') {
+      if (snapshot.keys['Enter'] || snapshot.keys[' ']) resetGame(getNextMissionIndex());
+      if (snapshot.keys['Escape']) ui.state = 'title';
+      return false;
+    }
+
+    return true;
+  };
+
+  return {
+    update,
+    isAudioMuted: () => audioMuted,
+  };
+}

--- a/src/game/missions/coordinator.ts
+++ b/src/game/missions/coordinator.ts
@@ -1,0 +1,614 @@
+import { parseTiled, type RuntimeTilemap } from '../../world/tiles/tiled';
+import missionJson from '../data/missions/sample_mission.json';
+import oceanMissionJson from '../data/missions/ocean_mission.json';
+import sampleMapJson from '../../world/tiles/sample_map.json';
+import oceanMapJson from '../../world/tiles/ocean_map.json';
+import { loadJson, saveJson } from '../../core/util/storage';
+import type { MissionTracker } from './tracker';
+import { loadMission } from './loader';
+import type { MissionDef, ObjectiveState } from './types';
+import { RNG } from '../../core/util/rng';
+import type { GameState } from '../app/state';
+import {
+  createMissionOneLayout,
+  createMissionTwoLayout,
+  cloneBuildingSite,
+  clonePadConfig,
+  clonePickupSite,
+  clonePoint,
+  cloneSafeHouseParams,
+  cloneSurvivorSite,
+  type PadConfig,
+  type BuildingSite,
+  type PickupSite,
+  type SurvivorSite,
+  type BoatLane,
+  type BoatWave,
+} from '../scenarios/layouts';
+import type { SafeHouseParams } from '../../render/sprites/safehouse';
+export type ObjectiveLabelFn = (objective: ObjectiveState) => string;
+
+export interface BoatScenarioConfig {
+  lanes: BoatLane[];
+  waves: BoatWave[];
+  maxEscapes: number;
+  nextWaveDelay: number;
+}
+
+interface ScenarioConfig {
+  map: RuntimeTilemap;
+  pad: PadConfig;
+  safeHouse: SafeHouseParams;
+  campusSites: BuildingSite[];
+  civilianGenerator?: () => BuildingSite[];
+  staticStructures?: BuildingSite[];
+  pickupSites: PickupSite[];
+  survivorSites: SurvivorSite[];
+  alienSpawnPoints: Array<{ tx: number; ty: number }>;
+  waveSpawnPoints: Array<{ tx: number; ty: number }>;
+  initialWaveCountdown?: number;
+  waveCooldown?: (index: number) => number;
+  waveSpawner?: (index: number) => boolean;
+  setupMissionHandlers: () => void;
+  setupObjectiveLabels: () => void;
+  onApply?: () => void;
+  onReset?: () => void;
+  spawnExtraEnemies?: () => void;
+}
+
+interface MissionProgressData {
+  current?: string;
+  unlocked?: string;
+  lastWin?: number;
+  mission?: string;
+}
+
+interface MissionBriefing {
+  title: string;
+  text: string;
+  goals: string[];
+}
+
+interface ScenarioRuntime {
+  id: string;
+  map: RuntimeTilemap;
+  isoParams: { tileWidth: number; tileHeight: number };
+  pad: PadConfig;
+  safeHouse: SafeHouseParams;
+  campusSites: BuildingSite[];
+  civilianGenerator: (() => BuildingSite[]) | null;
+  staticStructures: BuildingSite[];
+  buildingSites: BuildingSite[];
+  pickupSites: PickupSite[];
+  survivorSites: SurvivorSite[];
+  alienSpawnPoints: Array<{ tx: number; ty: number }>;
+  waveSpawnPoints: Array<{ tx: number; ty: number }>;
+  waveSpawner: ((index: number) => boolean) | null;
+  waveCooldown: ((index: number) => number) | null;
+  initialWaveCountdown: number;
+  spawnExtraEnemies?: () => void;
+  onReset?: () => void;
+  boatScenario: BoatScenarioConfig | null;
+}
+
+export interface MissionCoordinatorDeps {
+  rng: RNG;
+  state: GameState;
+  missionTracker: MissionTracker;
+  missionHandlers: Record<string, () => boolean>;
+  enemySpawners: {
+    spawnMissionEnemies: (
+      config: { mission: MissionDef; spawnExtraEnemies?: () => void },
+      spawnAlienStronghold: (type: 'AAA' | 'SAM', tx: number, ty: number) => void,
+    ) => void;
+    spawnCoastGuard: (point: { tx: number; ty: number }, leashRange: number) => void;
+    spawnShorePatrol: (route: { tx: number; ty: number; axis: 'x' | 'y'; range: number }) => void;
+    spawnSpeedboat: (lane: BoatLane, wave: number) => void;
+    spawnDefaultWave: (
+      waveIndex: number,
+      spawnPoints: Array<{ tx: number; ty: number }>,
+    ) => boolean;
+    spawnBoatWave: (
+      waveIndex: number,
+      boatScenario: { lanes: BoatLane[]; waves: BoatWave[] },
+    ) => boolean;
+  };
+  buildingSpawner: {
+    spawnAlienStronghold: (
+      type: 'AAA' | 'SAM',
+      tx: number,
+      ty: number,
+      spawnAlienUnit: (point: { tx: number; ty: number }) => void,
+    ) => void;
+  };
+  spawnAlienUnit: (point: { tx: number; ty: number }) => void;
+}
+
+export interface MissionCoordinator {
+  mission: MissionTracker;
+  objectiveLabelOverrides: Record<string, ObjectiveLabelFn>;
+  missionHandlers: Record<string, () => boolean>;
+  getScenario(): ScenarioRuntime;
+  initMissions(): void;
+  setMission(index: number): void;
+  getBriefing(): MissionBriefing;
+  getMissionIndices(): { current: number; next: number; highestUnlocked: number };
+  onMissionWin(): void;
+  getMissionDefs(): MissionDef[];
+  spawnMissionEnemies(): void;
+}
+
+const missionDefs: MissionDef[] = [missionJson as MissionDef, oceanMissionJson as MissionDef];
+
+const missionTilemaps: Record<string, RuntimeTilemap> = {
+  m01: parseTiled(sampleMapJson as unknown),
+  m02: parseTiled(oceanMapJson as unknown),
+};
+
+const missionOneLayout = createMissionOneLayout(missionTilemaps.m01);
+const missionTwoLayout = createMissionTwoLayout();
+
+const PROGRESS_KEY = 'choppa:progress';
+
+function createMissionBriefing(def: MissionDef): MissionBriefing {
+  return {
+    title: def.title,
+    text: def.briefing,
+    goals: def.objectives.map((o) => o.name),
+  };
+}
+
+function defaultWaveCooldown(index: number): number {
+  return Math.max(3, 5 - index * 0.2);
+}
+
+function boatWaveCooldown(index: number, boat: BoatScenarioConfig | null): number {
+  if (!boat) return Number.POSITIVE_INFINITY;
+  return index < boat.waves.length ? boat.nextWaveDelay : Number.POSITIVE_INFINITY;
+}
+
+function generateMissionOneCivilianHouses(rng: RNG): BuildingSite[] {
+  const clusters = missionOneLayout.civilianClusters ?? [];
+  const palettes = [
+    { body: '#7c95a3', roof: '#2f3f4d', ruin: '#3b2b2b' },
+    { body: '#9a7c6a', roof: '#4c3324', ruin: '#3c2018' },
+    { body: '#7f8f6b', roof: '#39482f', ruin: '#32291d' },
+    { body: '#a08aa3', roof: '#3d2c4b', ruin: '#352139' },
+  ];
+  const houses: BuildingSite[] = [];
+  for (let c = 0; c < clusters.length; c += 1) {
+    const cluster = clusters[c]!;
+    for (let i = 0; i < cluster.count; i += 1) {
+      const paletteRawIndex = Math.floor(rng.range(0, palettes.length));
+      const paletteIndex = Math.min(palettes.length - 1, paletteRawIndex);
+      const palette = palettes[paletteIndex]!;
+      houses.push({
+        tx: cluster.tx + rng.range(-cluster.spread, cluster.spread),
+        ty: cluster.ty + rng.range(-cluster.spread, cluster.spread),
+        width: 0.95 + rng.range(-0.1, 0.25),
+        depth: 0.95 + rng.range(-0.18, 0.2),
+        height: 18 + rng.range(-2, 4),
+        health: 60 + rng.range(-8, 10),
+        colliderRadius: 0.6 + rng.range(-0.04, 0.08),
+        bodyColor: palette.body,
+        roofColor: palette.roof,
+        ruinColor: palette.ruin,
+        score: 0,
+        category: 'civilian',
+        triggersAlarm: false,
+      });
+    }
+  }
+  if (houses.length > 0) {
+    const specialIndex = Math.min(houses.length - 1, Math.floor(rng.range(0, houses.length)));
+    houses[specialIndex] = {
+      ...houses[specialIndex]!,
+      drop: { kind: 'armor', amount: 35 },
+    };
+  }
+  return houses;
+}
+
+class MissionCoordinatorImpl implements MissionCoordinator {
+  public readonly mission: MissionTracker;
+
+  public readonly objectiveLabelOverrides: Record<string, ObjectiveLabelFn> = {};
+
+  public readonly missionHandlers: Record<string, () => boolean>;
+
+  private readonly rng: RNG;
+
+  private readonly state: GameState;
+
+  private readonly enemySpawners: MissionCoordinatorDeps['enemySpawners'];
+
+  private readonly buildingSpawner: MissionCoordinatorDeps['buildingSpawner'];
+
+  private readonly spawnAlienUnit: (point: { tx: number; ty: number }) => void;
+
+  private readonly scenarioConfigs: Record<string, ScenarioConfig>;
+
+  private missionProgress: MissionProgressData;
+
+  private currentMissionIndex: number;
+
+  private highestUnlockedMissionIndex: number;
+
+  private nextMissionIndex: number;
+
+  private missionDef: MissionDef;
+
+  private missionState = loadMission(missionDefs[0]!);
+
+  private missionBriefing: MissionBriefing = createMissionBriefing(missionDefs[0]!);
+
+  private scenario: ScenarioRuntime = {
+    id: missionDefs[0]!.id,
+    map: missionTilemaps.m01,
+    isoParams: {
+      tileWidth: missionTilemaps.m01.tileWidth,
+      tileHeight: missionTilemaps.m01.tileHeight,
+    },
+    pad: clonePadConfig(missionOneLayout.pad),
+    safeHouse: cloneSafeHouseParams(missionOneLayout.safeHouse),
+    campusSites: missionOneLayout.campusSites.map((site) => cloneBuildingSite(site)),
+    civilianGenerator: () => generateMissionOneCivilianHouses(this.rng),
+    staticStructures: [],
+    buildingSites: [],
+    pickupSites: missionOneLayout.pickupSites.map((site) => clonePickupSite(site)),
+    survivorSites: missionOneLayout.survivorSites.map((site) => cloneSurvivorSite(site)),
+    alienSpawnPoints: missionOneLayout.alienSpawnPoints.map((point) => clonePoint(point)),
+    waveSpawnPoints: missionOneLayout.waveSpawnPoints.map((point) => clonePoint(point)),
+    waveSpawner: null,
+    waveCooldown: null,
+    initialWaveCountdown: 3.5,
+    boatScenario: null,
+  };
+
+  public constructor(deps: MissionCoordinatorDeps) {
+    this.rng = deps.rng;
+    this.state = deps.state;
+    this.mission = deps.missionTracker;
+    this.missionHandlers = deps.missionHandlers;
+    this.enemySpawners = deps.enemySpawners;
+    this.buildingSpawner = deps.buildingSpawner;
+    this.spawnAlienUnit = deps.spawnAlienUnit;
+
+    this.scenarioConfigs = this.createScenarioConfigs();
+
+    const saved = loadJson<MissionProgressData>(PROGRESS_KEY, {});
+    this.currentMissionIndex = this.findMissionIndex(saved.current);
+    if (this.currentMissionIndex < 0) {
+      this.currentMissionIndex = this.findMissionIndex(saved.mission);
+    }
+    if (this.currentMissionIndex < 0) this.currentMissionIndex = 0;
+
+    this.highestUnlockedMissionIndex = this.findMissionIndex(saved.unlocked);
+    if (this.highestUnlockedMissionIndex < 0) {
+      const legacyIndex = this.findMissionIndex(saved.mission);
+      if (legacyIndex >= 0) {
+        this.highestUnlockedMissionIndex = Math.min(legacyIndex + 1, missionDefs.length - 1);
+      }
+    }
+    if (this.highestUnlockedMissionIndex < 0) {
+      this.highestUnlockedMissionIndex = this.currentMissionIndex;
+    }
+    this.highestUnlockedMissionIndex = Math.max(
+      this.highestUnlockedMissionIndex,
+      this.currentMissionIndex,
+    );
+
+    this.nextMissionIndex = Math.min(
+      this.currentMissionIndex + 1,
+      this.highestUnlockedMissionIndex,
+    );
+
+    this.missionProgress = {
+      current: missionDefs[this.currentMissionIndex]?.id ?? missionDefs[0]?.id,
+      unlocked: missionDefs[this.highestUnlockedMissionIndex]?.id ?? missionDefs[0]?.id,
+      lastWin: saved.lastWin,
+    };
+
+    this.missionDef = missionDefs[this.currentMissionIndex]!;
+    this.missionState = loadMission(this.missionDef);
+    this.mission.state = this.missionState;
+    this.missionBriefing = createMissionBriefing(this.missionDef);
+
+    this.applyScenario(this.missionDef.id);
+    this.persistProgress();
+  }
+
+  public getScenario(): ScenarioRuntime {
+    return this.scenario;
+  }
+
+  public initMissions(): void {
+    this.setMission(this.currentMissionIndex);
+  }
+
+  public setMission(index: number): void {
+    const clamped = Math.min(Math.max(index, 0), missionDefs.length - 1);
+    this.currentMissionIndex = clamped;
+    if (this.highestUnlockedMissionIndex < this.currentMissionIndex) {
+      this.highestUnlockedMissionIndex = this.currentMissionIndex;
+    }
+    this.missionDef = missionDefs[this.currentMissionIndex]!;
+    this.missionState = loadMission(this.missionDef);
+    this.mission.state = this.missionState;
+    this.missionBriefing = createMissionBriefing(this.missionDef);
+    this.applyScenario(this.missionDef.id);
+    this.nextMissionIndex = Math.min(
+      this.currentMissionIndex + 1,
+      this.highestUnlockedMissionIndex,
+    );
+    this.missionProgress.current =
+      missionDefs[this.currentMissionIndex]?.id ?? this.missionProgress.current;
+    this.missionProgress.unlocked =
+      missionDefs[this.highestUnlockedMissionIndex]?.id ?? this.missionProgress.unlocked;
+    this.persistProgress();
+  }
+
+  public getBriefing(): MissionBriefing {
+    return this.missionBriefing;
+  }
+
+  public getMissionIndices(): { current: number; next: number; highestUnlocked: number } {
+    return {
+      current: this.currentMissionIndex,
+      next: this.nextMissionIndex,
+      highestUnlocked: this.highestUnlockedMissionIndex,
+    };
+  }
+
+  public onMissionWin(): void {
+    const candidate = Math.min(this.currentMissionIndex + 1, missionDefs.length - 1);
+    if (candidate > this.highestUnlockedMissionIndex) {
+      this.highestUnlockedMissionIndex = candidate;
+    }
+    this.nextMissionIndex = Math.min(candidate, this.highestUnlockedMissionIndex);
+    this.missionProgress.unlocked =
+      missionDefs[this.highestUnlockedMissionIndex]?.id ?? this.missionProgress.unlocked;
+    this.missionProgress.lastWin = Date.now();
+    this.persistProgress();
+  }
+
+  public getMissionDefs(): MissionDef[] {
+    return missionDefs;
+  }
+
+  public spawnMissionEnemies(): void {
+    this.enemySpawners.spawnMissionEnemies(
+      { mission: this.mission.state.def, spawnExtraEnemies: this.scenario.spawnExtraEnemies },
+      (type, tx, ty) =>
+        this.buildingSpawner.spawnAlienStronghold(type, tx, ty, this.spawnAlienUnit),
+    );
+  }
+
+  private persistProgress(): void {
+    saveJson(PROGRESS_KEY, this.missionProgress);
+  }
+
+  private findMissionIndex(id?: string): number {
+    if (!id) return -1;
+    return missionDefs.findIndex((def) => def.id === id);
+  }
+
+  private applyScenario(id: string): void {
+    const config = this.scenarioConfigs[id];
+    if (!config) throw new Error(`Unknown mission scenario: ${id}`);
+
+    this.scenario = {
+      id,
+      map: config.map,
+      isoParams: { tileWidth: config.map.tileWidth, tileHeight: config.map.tileHeight },
+      pad: clonePadConfig(config.pad),
+      safeHouse: cloneSafeHouseParams(config.safeHouse),
+      campusSites: config.campusSites.map((site) => cloneBuildingSite(site)),
+      civilianGenerator: config.civilianGenerator ?? null,
+      staticStructures: config.staticStructures
+        ? config.staticStructures.map((site) => cloneBuildingSite(site))
+        : [],
+      buildingSites: [],
+      pickupSites: config.pickupSites.map((site) => clonePickupSite(site)),
+      survivorSites: config.survivorSites.map((site) => cloneSurvivorSite(site)),
+      alienSpawnPoints: config.alienSpawnPoints.map((point) => clonePoint(point)),
+      waveSpawnPoints: config.waveSpawnPoints.map((point) => clonePoint(point)),
+      waveSpawner: config.waveSpawner ?? null,
+      waveCooldown: config.waveCooldown ?? ((index: number) => defaultWaveCooldown(index)),
+      initialWaveCountdown: config.initialWaveCountdown ?? 3.5,
+      spawnExtraEnemies: config.spawnExtraEnemies,
+      onReset: config.onReset,
+      boatScenario: null,
+    };
+
+    this.regenerateWorldStructures();
+
+    if (config.onApply) config.onApply();
+
+    for (const key of Object.keys(this.objectiveLabelOverrides))
+      delete this.objectiveLabelOverrides[key];
+    for (const key of Object.keys(this.missionHandlers)) delete this.missionHandlers[key];
+
+    config.setupMissionHandlers();
+    config.setupObjectiveLabels();
+
+    this.state.rescue.carrying = 0;
+    this.state.rescue.rescued = 0;
+    this.state.rescue.survivorsSpawned = false;
+    this.state.rescue.total = this.scenario.survivorSites.reduce(
+      (sum, site) => sum + site.count,
+      0,
+    );
+
+    this.state.flags.aliensTriggered = false;
+    this.state.flags.aliensDefeated = false;
+    this.state.flags.campusLeveled = false;
+
+    this.state.boat.boatsEscaped = 0;
+    this.state.boat.objectiveComplete = false;
+    this.state.boat.objectiveFailed = false;
+    this.state.boat.scenario = this.scenario.boatScenario;
+
+    this.state.wave.index = 0;
+    this.state.wave.countdown = this.scenario.initialWaveCountdown;
+    this.state.wave.active = false;
+    this.state.wave.timeInWave = 0;
+    this.state.wave.enemies.clear();
+  }
+
+  private regenerateWorldStructures(): void {
+    const structures = this.scenario.civilianGenerator ? this.scenario.civilianGenerator() : [];
+    const buildingSites: BuildingSite[] = [...this.scenario.campusSites];
+    if (structures.length > 0) buildingSites.push(...structures);
+    if (this.scenario.staticStructures.length > 0) {
+      buildingSites.push(...this.scenario.staticStructures);
+    }
+    this.scenario.buildingSites = buildingSites;
+  }
+
+  private createScenarioConfigs(): Record<string, ScenarioConfig> {
+    return {
+      m01: {
+        map: missionTilemaps.m01,
+        pad: missionOneLayout.pad,
+        safeHouse: missionOneLayout.safeHouse,
+        campusSites: missionOneLayout.campusSites,
+        civilianGenerator: () => generateMissionOneCivilianHouses(this.rng),
+        pickupSites: missionOneLayout.pickupSites,
+        survivorSites: missionOneLayout.survivorSites,
+        alienSpawnPoints: missionOneLayout.alienSpawnPoints,
+        waveSpawnPoints: missionOneLayout.waveSpawnPoints,
+        initialWaveCountdown: 3.5,
+        waveCooldown: (index: number) => defaultWaveCooldown(index),
+        waveSpawner: (index: number) =>
+          this.enemySpawners.spawnDefaultWave(index, this.scenario.waveSpawnPoints),
+        setupMissionHandlers: () => this.setupMissionOneHandlers(),
+        setupObjectiveLabels: () => this.setupMissionOneObjectiveLabels(),
+        onApply: () => {
+          this.state.boat.scenario = null;
+          this.state.boat.boatsEscaped = 0;
+          this.state.boat.objectiveComplete = false;
+          this.state.boat.objectiveFailed = false;
+        },
+      },
+      m02: {
+        map: missionTilemaps.m02,
+        pad: missionTwoLayout.pad,
+        safeHouse: missionTwoLayout.safeHouse,
+        campusSites: missionTwoLayout.campusSites,
+        staticStructures: missionTwoLayout.staticStructures,
+        pickupSites: missionTwoLayout.pickupSites,
+        survivorSites: missionTwoLayout.survivorSites,
+        alienSpawnPoints: missionTwoLayout.alienSpawnPoints,
+        waveSpawnPoints: missionTwoLayout.waveSpawnPoints,
+        initialWaveCountdown: 4.5,
+        waveCooldown: (index: number) => boatWaveCooldown(index, this.state.boat.scenario),
+        waveSpawner: (index: number) => {
+          const boat = this.state.boat.scenario;
+          return boat ? this.enemySpawners.spawnBoatWave(index, boat) : false;
+        },
+        setupMissionHandlers: () => this.setupMissionTwoHandlers(),
+        setupObjectiveLabels: () => this.setupMissionTwoObjectiveLabels(),
+        onApply: () => {
+          this.activateBoatScenario();
+        },
+        onReset: () => {
+          this.state.boat.boatsEscaped = 0;
+          this.state.boat.objectiveComplete = false;
+          this.state.boat.objectiveFailed = false;
+        },
+        spawnExtraEnemies: () => this.spawnMissionTwoGuards(),
+      },
+    };
+  }
+
+  private activateBoatScenario(): void {
+    const boat = missionTwoLayout.boat;
+    if (!boat) {
+      this.state.boat.scenario = null;
+      this.scenario.boatScenario = null;
+      return;
+    }
+    const scenario: BoatScenarioConfig = {
+      lanes: boat.lanes.map((lane) => ({
+        entry: { ...lane.entry },
+        target: { ...lane.target },
+      })),
+      waves: boat.waves.map((wave) => ({ ...wave })),
+      maxEscapes: boat.maxEscapes,
+      nextWaveDelay: boat.nextWaveDelay,
+    };
+    this.scenario.boatScenario = scenario;
+    this.state.boat.scenario = scenario;
+    this.state.boat.boatsEscaped = 0;
+    this.state.boat.objectiveComplete = false;
+    this.state.boat.objectiveFailed = false;
+  }
+
+  private spawnMissionTwoGuards(): void {
+    const guardPosts = missionTwoLayout.guardPosts ?? [];
+    for (let i = 0; i < guardPosts.length; i += 1) {
+      this.enemySpawners.spawnCoastGuard(guardPosts[i]!, 9.2);
+    }
+    const patrolRoutes = missionTwoLayout.patrolRoutes ?? [];
+    for (let i = 0; i < patrolRoutes.length; i += 1) {
+      this.enemySpawners.spawnShorePatrol(patrolRoutes[i]!);
+    }
+  }
+
+  private setupMissionOneHandlers(): void {
+    this.missionHandlers.obj4 = () =>
+      this.state.flags.aliensTriggered && this.state.flags.aliensDefeated;
+    this.missionHandlers.obj5 = () => this.state.rescue.rescued >= this.state.rescue.total;
+  }
+
+  private setupMissionOneObjectiveLabels(): void {
+    this.objectiveLabelOverrides.obj4 = (objective) => {
+      if (!this.state.flags.aliensTriggered) return `${objective.name} (stand by)`;
+      if (!objective.complete)
+        return `${objective.name} (${this.state.alienEntities.size} remaining)`;
+      return objective.name;
+    };
+    this.objectiveLabelOverrides.obj5 = (objective) => {
+      const carrying = this.state.rescue.carrying;
+      let label = `${objective.name} (${this.state.rescue.rescued}/${this.state.rescue.total}`;
+      if (carrying > 0) label += ` +${carrying}`;
+      label += ')';
+      return label;
+    };
+  }
+
+  private setupMissionTwoHandlers(): void {
+    this.missionHandlers.boats = () =>
+      this.state.boat.objectiveComplete && !this.state.boat.objectiveFailed;
+  }
+
+  private setupMissionTwoObjectiveLabels(): void {
+    this.objectiveLabelOverrides.boats = (objective) => {
+      const boat = this.state.boat.scenario;
+      if (!boat) return objective.name;
+      const totalWaves = boat.waves.length;
+      const currentWave = this.state.wave.active
+        ? this.state.wave.index
+        : Math.min(this.state.wave.index + 1, totalWaves);
+      let label = `${objective.name} (Escaped: ${this.state.boat.boatsEscaped}/${boat.maxEscapes}`;
+      if (!objective.complete) {
+        const clampedWave = Math.min(Math.max(currentWave, 1), totalWaves);
+        label += ` | Wave ${clampedWave} of ${totalWaves}`;
+        if (
+          !this.state.wave.active &&
+          this.state.wave.index < totalWaves &&
+          Number.isFinite(this.state.wave.countdown)
+        ) {
+          label += ` | Next wave in: ${Math.max(0, this.state.wave.countdown).toFixed(1)}s`;
+        }
+      }
+      label += ')';
+      return label;
+    };
+  }
+}
+
+export function createMissionCoordinator(deps: MissionCoordinatorDeps): MissionCoordinator {
+  return new MissionCoordinatorImpl(deps);
+}

--- a/src/game/spawn/buildings.ts
+++ b/src/game/spawn/buildings.ts
@@ -1,0 +1,195 @@
+import { ComponentStore } from '../../core/ecs/components';
+import { EntityRegistry, type Entity } from '../../core/ecs/entities';
+import type { Transform } from '../components/Transform';
+import type { Building } from '../components/Building';
+import type { Health } from '../components/Health';
+import type { Collider } from '../components/Collider';
+import type { GameState } from '../app/state';
+import type { BuildingSite } from '../scenarios/layouts';
+
+export interface BuildingStores {
+  transforms: ComponentStore<Transform>;
+  buildings: ComponentStore<Building>;
+  healths: ComponentStore<Health>;
+  colliders: ComponentStore<Collider>;
+}
+
+export interface BuildingFactoryDeps {
+  entities: EntityRegistry;
+  stores: BuildingStores;
+  state: GameState;
+  destroyEntity: (entity: Entity) => void;
+}
+
+export function createBuildingFactory({
+  entities,
+  stores,
+  state,
+  destroyEntity,
+}: BuildingFactoryDeps): {
+  createBuildingEntity: (site: BuildingSite) => Entity;
+  spawnBuildings: (sites: BuildingSite[]) => void;
+  clearBuildings: () => void;
+  spawnAlienStronghold: (
+    type: 'AAA' | 'SAM',
+    tx: number,
+    ty: number,
+    spawnAlienUnit: (point: { tx: number; ty: number }) => void,
+  ) => void;
+} {
+  const createBuildingEntity = (site: BuildingSite): Entity => {
+    const entity = entities.create();
+    stores.transforms.set(entity, { tx: site.tx, ty: site.ty, rot: 0 });
+    stores.buildings.set(entity, {
+      width: site.width,
+      depth: site.depth,
+      height: site.height,
+      bodyColor: site.bodyColor,
+      roofColor: site.roofColor,
+      ruinColor: site.ruinColor,
+    });
+    stores.healths.set(entity, { current: site.health, max: site.health });
+    stores.colliders.set(entity, { radius: site.colliderRadius, team: 'enemy' });
+    state.buildingMeta.set(entity, {
+      score: site.score ?? 0,
+      drop: site.drop,
+      category: site.category ?? 'civilian',
+      triggersAlarm: Boolean(site.triggersAlarm),
+    });
+    state.buildingEntities.push(entity);
+    return entity;
+  };
+
+  const spawnBuildings = (sites: BuildingSite[]): void => {
+    clearBuildings();
+    for (let i = 0; i < sites.length; i += 1) {
+      createBuildingEntity(sites[i]!);
+    }
+  };
+
+  const clearBuildings = (): void => {
+    for (let i = state.buildingEntities.length - 1; i >= 0; i -= 1) {
+      destroyEntity(state.buildingEntities[i]!);
+    }
+    state.buildingEntities.length = 0;
+  };
+
+  const spawnAlienStronghold = (
+    type: 'AAA' | 'SAM',
+    tx: number,
+    ty: number,
+    spawnAlienUnit: (point: { tx: number; ty: number }) => void,
+  ): void => {
+    const strongholdStructures: BuildingSite[] =
+      type === 'AAA'
+        ? [
+            {
+              tx: tx - 0.85,
+              ty: ty + 0.55,
+              width: 1.15,
+              depth: 0.95,
+              height: 22,
+              health: 85,
+              colliderRadius: 0.7,
+              bodyColor: '#25143c',
+              roofColor: '#6efdd4',
+              ruinColor: '#341d4d',
+              score: 130,
+              category: 'stronghold',
+            },
+            {
+              tx: tx + 0.9,
+              ty: ty - 0.45,
+              width: 1.05,
+              depth: 0.85,
+              height: 20,
+              health: 80,
+              colliderRadius: 0.68,
+              bodyColor: '#28163f',
+              roofColor: '#63f0c8',
+              ruinColor: '#2f1744',
+              score: 130,
+              category: 'stronghold',
+            },
+            {
+              tx: tx,
+              ty: ty + 0.9,
+              width: 1.6,
+              depth: 0.6,
+              height: 16,
+              health: 70,
+              colliderRadius: 0.65,
+              bodyColor: '#1f0f32',
+              roofColor: '#8bf9e1',
+              ruinColor: '#2a123d',
+              score: 110,
+              category: 'stronghold',
+            },
+          ]
+        : [
+            {
+              tx: tx,
+              ty: ty - 0.95,
+              width: 1.6,
+              depth: 1.15,
+              height: 30,
+              health: 140,
+              colliderRadius: 0.88,
+              bodyColor: '#1f1d46',
+              roofColor: '#7afbe9',
+              ruinColor: '#261b3d',
+              score: 200,
+              category: 'stronghold',
+            },
+            {
+              tx: tx - 1.15,
+              ty: ty + 0.55,
+              width: 1.1,
+              depth: 0.9,
+              height: 24,
+              health: 90,
+              colliderRadius: 0.72,
+              bodyColor: '#261548',
+              roofColor: '#5cf3db',
+              ruinColor: '#2e1a4f',
+              score: 150,
+              category: 'stronghold',
+            },
+            {
+              tx: tx + 1.1,
+              ty: ty + 0.65,
+              width: 1.15,
+              depth: 0.95,
+              height: 24,
+              health: 90,
+              colliderRadius: 0.74,
+              bodyColor: '#2a184d',
+              roofColor: '#68f8e1',
+              ruinColor: '#311e53',
+              score: 150,
+              category: 'stronghold',
+            },
+          ];
+    for (let i = 0; i < strongholdStructures.length; i += 1) {
+      const site = strongholdStructures[i]!;
+      createBuildingEntity({ ...site, triggersAlarm: false });
+    }
+
+    const defenders =
+      type === 'AAA'
+        ? [
+            { tx: tx - 1.2, ty: ty + 0.2 },
+            { tx: tx + 1, ty: ty - 0.1 },
+          ]
+        : [
+            { tx: tx - 1.25, ty: ty + 0.2 },
+            { tx: tx + 1.2, ty: ty + 0.3 },
+            { tx: tx + 0.1, ty: ty - 1.2 },
+          ];
+    for (let i = 0; i < defenders.length; i += 1) {
+      spawnAlienUnit(defenders[i]!);
+    }
+  };
+
+  return { createBuildingEntity, spawnBuildings, clearBuildings, spawnAlienStronghold };
+}

--- a/src/game/spawn/enemies.ts
+++ b/src/game/spawn/enemies.ts
@@ -1,0 +1,342 @@
+import { ComponentStore } from '../../core/ecs/components';
+import { EntityRegistry, type Entity } from '../../core/ecs/entities';
+import type { Transform } from '../components/Transform';
+import type { Physics } from '../components/Physics';
+import type { Health } from '../components/Health';
+import type { Collider } from '../components/Collider';
+import type { AAA, SAM, PatrolDrone, ChaserDrone } from '../components/AI';
+import type { Speedboat } from '../components/Speedboat';
+import type { GameState, EnemyMeta } from '../app/state';
+import { RNG } from '../../core/util/rng';
+import type { MissionDef } from '../missions/types';
+import type { BoatLane, BoatWave } from '../scenarios/layouts';
+
+export interface EnemyStores {
+  transforms: ComponentStore<Transform>;
+  physics: ComponentStore<Physics>;
+  healths: ComponentStore<Health>;
+  colliders: ComponentStore<Collider>;
+  aaas: ComponentStore<AAA>;
+  sams: ComponentStore<SAM>;
+  patrols: ComponentStore<PatrolDrone>;
+  chasers: ComponentStore<ChaserDrone>;
+  speedboats: ComponentStore<Speedboat>;
+}
+
+export interface EnemyFactoryDeps {
+  entities: EntityRegistry;
+  stores: EnemyStores;
+  rng: RNG;
+  state: GameState;
+  registerEnemy: (entity: Entity, meta: EnemyMeta) => void;
+}
+
+export interface MissionSpawnConfig {
+  mission: MissionDef;
+  spawnExtraEnemies?: () => void;
+}
+
+export function createEnemyFactory({
+  entities,
+  stores,
+  rng,
+  state,
+  registerEnemy,
+}: EnemyFactoryDeps): {
+  spawnMissionEnemies: (
+    config: MissionSpawnConfig,
+    spawnAlienStronghold: (type: 'AAA' | 'SAM', tx: number, ty: number) => void,
+  ) => void;
+  spawnCoastGuard: (point: { tx: number; ty: number }, leashRange: number) => void;
+  spawnShorePatrol: (route: { tx: number; ty: number; axis: 'x' | 'y'; range: number }) => void;
+  spawnPatrolEnemy: (point: { tx: number; ty: number }, wave: number, axis: 'x' | 'y') => Entity;
+  spawnChaserEnemy: (point: { tx: number; ty: number }, wave: number) => Entity;
+  spawnAlienUnit: (point: { tx: number; ty: number }) => void;
+  spawnSpeedboat: (lane: BoatLane, wave: number) => void;
+  spawnDefaultWave: (waveIndex: number, spawnPoints: Array<{ tx: number; ty: number }>) => boolean;
+  spawnBoatWave: (
+    waveIndex: number,
+    boatScenario: { lanes: BoatLane[]; waves: BoatWave[] },
+  ) => boolean;
+} {
+  const spawnCoastGuard = (point: { tx: number; ty: number }, leashRange: number): void => {
+    const entity = entities.create();
+    stores.transforms.set(entity, { tx: point.tx, ty: point.ty, rot: 0 });
+    stores.physics.set(entity, {
+      vx: 0,
+      vy: 0,
+      ax: 0,
+      ay: 0,
+      drag: 0.72,
+      maxSpeed: 3.4,
+      turnRate: Math.PI * 1.5,
+    });
+    stores.healths.set(entity, { current: 38, max: 38 });
+    stores.colliders.set(entity, { radius: 0.35, team: 'enemy' });
+    stores.chasers.set(entity, {
+      speed: 3.1,
+      acceleration: 3.5,
+      fireRange: 6.5,
+      fireInterval: 1.05,
+      cooldown: 0,
+      spread: 0.2,
+      guard: {
+        homeX: point.tx,
+        homeY: point.ty,
+        holdRadius: 0.6,
+        aggroRange: 6.8,
+        leashRange,
+        alerted: false,
+      },
+    });
+    registerEnemy(entity, { kind: 'chaser', score: 250 });
+  };
+
+  const spawnShorePatrol = (route: {
+    tx: number;
+    ty: number;
+    axis: 'x' | 'y';
+    range: number;
+  }): void => {
+    const entity = entities.create();
+    stores.transforms.set(entity, { tx: route.tx, ty: route.ty, rot: 0 });
+    stores.physics.set(entity, {
+      vx: 0,
+      vy: 0,
+      ax: 0,
+      ay: 0,
+      drag: 0.86,
+      maxSpeed: 2.3,
+      turnRate: Math.PI,
+    });
+    stores.healths.set(entity, { current: 28, max: 28 });
+    stores.colliders.set(entity, { radius: 0.38, team: 'enemy' });
+    stores.patrols.set(entity, {
+      axis: route.axis,
+      originX: route.tx,
+      originY: route.ty,
+      range: route.range,
+      speed: 2.1,
+      direction: rng.float01() > 0.5 ? 1 : -1,
+      fireRange: 6.4,
+      fireInterval: 1.15,
+      cooldown: 0,
+    });
+    registerEnemy(entity, { kind: 'patrol', score: 165 });
+  };
+
+  const spawnPatrolEnemy = (
+    point: { tx: number; ty: number },
+    wave: number,
+    axis: 'x' | 'y',
+  ): Entity => {
+    const entity = entities.create();
+    stores.transforms.set(entity, { tx: point.tx, ty: point.ty, rot: 0 });
+    stores.physics.set(entity, {
+      vx: 0,
+      vy: 0,
+      ax: 0,
+      ay: 0,
+      drag: 0.9,
+      maxSpeed: 2.2 + wave * 0.1,
+      turnRate: Math.PI,
+    });
+    stores.healths.set(entity, { current: 22 + wave * 3, max: 22 + wave * 3 });
+    stores.colliders.set(entity, { radius: 0.4, team: 'enemy' });
+    stores.patrols.set(entity, {
+      axis,
+      originX: point.tx,
+      originY: point.ty,
+      range: 2.5 + Math.min(4, wave * 0.6),
+      speed: 1.8 + wave * 0.2,
+      direction: rng.float01() > 0.5 ? 1 : -1,
+      fireRange: 6.5,
+      fireInterval: Math.max(0.9, 1.4 - wave * 0.1),
+      cooldown: 0,
+    });
+    registerEnemy(entity, { kind: 'patrol', score: 125 + wave * 15, wave });
+    return entity;
+  };
+
+  const spawnChaserEnemy = (point: { tx: number; ty: number }, wave: number): Entity => {
+    const entity = entities.create();
+    stores.transforms.set(entity, { tx: point.tx, ty: point.ty, rot: 0 });
+    stores.physics.set(entity, {
+      vx: 0,
+      vy: 0,
+      ax: 0,
+      ay: 0,
+      drag: 0.7,
+      maxSpeed: 3.2 + wave * 0.25,
+      turnRate: Math.PI * 1.4,
+    });
+    stores.healths.set(entity, { current: 26 + wave * 4, max: 26 + wave * 4 });
+    stores.colliders.set(entity, { radius: 0.35, team: 'enemy' });
+    stores.chasers.set(entity, {
+      speed: 2.6 + wave * 0.25,
+      acceleration: 3.2,
+      fireRange: 6,
+      fireInterval: Math.max(0.8, 1.3 - wave * 0.1),
+      cooldown: 0,
+      spread: 0.18,
+    });
+    registerEnemy(entity, { kind: 'chaser', score: 220 + wave * 20, wave });
+    return entity;
+  };
+
+  const spawnAlienUnit = (point: { tx: number; ty: number }): void => {
+    const entity = entities.create();
+    stores.transforms.set(entity, { tx: point.tx, ty: point.ty, rot: 0 });
+    stores.physics.set(entity, {
+      vx: 0,
+      vy: 0,
+      ax: 0,
+      ay: 0,
+      drag: 0.7,
+      maxSpeed: 3.4,
+      turnRate: Math.PI * 1.5,
+    });
+    stores.healths.set(entity, { current: 36, max: 36 });
+    stores.colliders.set(entity, { radius: 0.35, team: 'enemy' });
+    stores.chasers.set(entity, {
+      speed: 3.1,
+      acceleration: 3.6,
+      fireRange: 6.6,
+      fireInterval: 1,
+      cooldown: 0,
+      spread: 0.22,
+      guard: {
+        homeX: point.tx,
+        homeY: point.ty,
+        holdRadius: 0.45,
+        aggroRange: 5.6,
+        leashRange: 9.5,
+        alerted: false,
+      },
+    });
+    registerEnemy(entity, { kind: 'chaser', score: 260 });
+    state.alienEntities.add(entity);
+  };
+
+  const spawnSpeedboat = (lane: BoatLane, wave: number): void => {
+    const entity = entities.create();
+    const entryJitter = (rng.float01() - 0.5) * 0.6;
+    const entryJitterY = (rng.float01() - 0.5) * 0.4;
+    const cruiseSpeed = 2.4 + wave * 0.18;
+    stores.transforms.set(entity, {
+      tx: lane.entry.tx + entryJitter,
+      ty: lane.entry.ty + entryJitterY,
+      rot: 0,
+    });
+    stores.physics.set(entity, {
+      vx: 0,
+      vy: 0,
+      ax: 0,
+      ay: 0,
+      drag: 0.78,
+      maxSpeed: cruiseSpeed + 0.4,
+      turnRate: Math.PI,
+    });
+    stores.healths.set(entity, { current: 24 + wave * 4, max: 24 + wave * 4 });
+    stores.colliders.set(entity, { radius: 0.4, team: 'enemy' });
+    stores.speedboats.set(entity, {
+      targetX: lane.target.tx + (rng.float01() - 0.5) * 0.5,
+      targetY: lane.target.ty + (rng.float01() - 0.5) * 0.5,
+      speed: cruiseSpeed,
+      acceleration: 2.6,
+      fireRange: 6.2,
+      fireInterval: Math.max(0.95, 1.3 - wave * 0.08),
+      cooldown: 0,
+      arrivalRadius: 0.6,
+      activationRange: 7.5,
+      activated: false,
+    });
+    registerEnemy(entity, { kind: 'speedboat', score: 220 + wave * 25, wave });
+  };
+
+  const spawnMissionEnemies = (
+    config: MissionSpawnConfig,
+    spawnAlienStronghold: (type: 'AAA' | 'SAM', tx: number, ty: number) => void,
+  ): void => {
+    const spawns = config.mission.enemySpawns ?? [];
+    for (let i = 0; i < spawns.length; i += 1) {
+      const spawn = spawns[i]!;
+      const entity = entities.create();
+      stores.transforms.set(entity, { tx: spawn.at.tx, ty: spawn.at.ty, rot: 0 });
+      stores.healths.set(entity, { current: 30, max: 30 });
+      stores.colliders.set(entity, { radius: 0.5, team: 'enemy' });
+      if (spawn.type === 'AAA') {
+        stores.aaas.set(entity, {
+          range: 8,
+          cooldown: 0,
+          fireInterval: 0.6,
+          projectileSpeed: 12,
+          spread: 0.06,
+        });
+        registerEnemy(entity, { kind: 'aaa', score: 150 });
+        spawnAlienStronghold('AAA', spawn.at.tx, spawn.at.ty);
+      } else {
+        stores.sams.set(entity, {
+          range: 12,
+          lockTime: 0.8,
+          cooldown: 0,
+          fireInterval: 2.5,
+          turnRate: Math.PI * 0.7,
+          missileSpeed: 6,
+          lockProgress: 0,
+        });
+        registerEnemy(entity, { kind: 'sam', score: 200 });
+        spawnAlienStronghold('SAM', spawn.at.tx, spawn.at.ty);
+      }
+    }
+    if (config.spawnExtraEnemies) config.spawnExtraEnemies();
+  };
+
+  const spawnDefaultWave = (
+    waveIndex: number,
+    spawnPoints: Array<{ tx: number; ty: number }>,
+  ): boolean => {
+    if (spawnPoints.length === 0) return false;
+    state.wave.enemies.clear();
+    const patrolCount = Math.min(spawnPoints.length, 2 + waveIndex);
+    const chaserCount = Math.min(spawnPoints.length, Math.max(0, Math.floor(waveIndex / 2)));
+    for (let i = 0; i < patrolCount; i += 1) {
+      const point = spawnPoints[i % spawnPoints.length]!;
+      const axis: 'x' | 'y' = i % 2 === 0 ? 'x' : 'y';
+      spawnPatrolEnemy(point, waveIndex, axis);
+    }
+    for (let i = 0; i < chaserCount; i += 1) {
+      const point = spawnPoints[(i + patrolCount) % spawnPoints.length]!;
+      spawnChaserEnemy(point, waveIndex);
+    }
+    return true;
+  };
+
+  const spawnBoatWave = (
+    waveIndex: number,
+    boatScenario: { lanes: BoatLane[]; waves: BoatWave[] },
+  ): boolean => {
+    if (!boatScenario || boatScenario.lanes.length === 0) return false;
+    state.wave.enemies.clear();
+    const waveDef = boatScenario.waves[waveIndex - 1];
+    if (!waveDef) return false;
+    const laneOffset = Math.floor(rng.range(0, boatScenario.lanes.length));
+    for (let i = 0; i < waveDef.count; i += 1) {
+      const lane = boatScenario.lanes[(i + laneOffset) % boatScenario.lanes.length]!;
+      spawnSpeedboat(lane, waveIndex);
+    }
+    return waveDef.count > 0;
+  };
+
+  return {
+    spawnMissionEnemies,
+    spawnCoastGuard,
+    spawnShorePatrol,
+    spawnPatrolEnemy,
+    spawnChaserEnemy,
+    spawnAlienUnit,
+    spawnSpeedboat,
+    spawnDefaultWave,
+    spawnBoatWave,
+  };
+}

--- a/src/game/spawn/lifecycle.ts
+++ b/src/game/spawn/lifecycle.ts
@@ -1,0 +1,98 @@
+import { ComponentStore } from '../../core/ecs/components';
+import { EntityRegistry, type Entity } from '../../core/ecs/entities';
+import type { Transform } from '../components/Transform';
+import type { Physics } from '../components/Physics';
+import type { Fuel } from '../components/Fuel';
+import type { Sprite } from '../components/Sprite';
+import type { Ammo } from '../components/Ammo';
+import type { WeaponHolder } from '../components/Weapon';
+import type { AAA, SAM, PatrolDrone, ChaserDrone } from '../components/AI';
+import type { Health } from '../components/Health';
+import type { Collider } from '../components/Collider';
+import type { Building } from '../components/Building';
+import type { Pickup } from '../components/Pickup';
+import type { Speedboat } from '../components/Speedboat';
+import type { GameState, EnemyMeta } from '../app/state';
+
+export interface LifecycleStores {
+  transforms: ComponentStore<Transform>;
+  physics: ComponentStore<Physics>;
+  fuels: ComponentStore<Fuel>;
+  sprites: ComponentStore<Sprite>;
+  ammos: ComponentStore<Ammo>;
+  weapons: ComponentStore<WeaponHolder>;
+  aaas: ComponentStore<AAA>;
+  sams: ComponentStore<SAM>;
+  patrols: ComponentStore<PatrolDrone>;
+  chasers: ComponentStore<ChaserDrone>;
+  speedboats: ComponentStore<Speedboat>;
+  healths: ComponentStore<Health>;
+  colliders: ComponentStore<Collider>;
+  buildings: ComponentStore<Building>;
+  pickups: ComponentStore<Pickup>;
+}
+
+export interface LifecycleDeps {
+  entities: EntityRegistry;
+  stores: LifecycleStores;
+  state: GameState;
+}
+
+export function createEntityLifecycle({ entities, stores, state }: LifecycleDeps): {
+  destroyEntity: (entity: Entity) => void;
+  registerEnemy: (entity: Entity, meta: EnemyMeta) => void;
+  clearEnemies: () => void;
+} {
+  const destroyEntity = (entity: Entity): void => {
+    if (state.playerId === entity) return;
+    const soundHandle = state.pickupCraneSounds.get(entity);
+    if (soundHandle) {
+      soundHandle.cancel();
+      state.pickupCraneSounds.delete(entity);
+    }
+
+    stores.transforms.remove(entity);
+    stores.physics.remove(entity);
+    stores.fuels.remove(entity);
+    stores.sprites.remove(entity);
+    stores.ammos.remove(entity);
+    stores.weapons.remove(entity);
+    stores.aaas.remove(entity);
+    stores.sams.remove(entity);
+    stores.patrols.remove(entity);
+    stores.chasers.remove(entity);
+    stores.speedboats.remove(entity);
+    stores.healths.remove(entity);
+    stores.colliders.remove(entity);
+    stores.buildings.remove(entity);
+    stores.pickups.remove(entity);
+
+    state.buildingMeta.delete(entity);
+    const buildingIndex = state.buildingEntities.indexOf(entity);
+    if (buildingIndex !== -1) state.buildingEntities.splice(buildingIndex, 1);
+    const pickupIndex = state.pickupEntities.indexOf(entity);
+    if (pickupIndex !== -1) state.pickupEntities.splice(pickupIndex, 1);
+    const survivorIndex = state.survivorEntities.indexOf(entity);
+    if (survivorIndex !== -1) state.survivorEntities.splice(survivorIndex, 1);
+
+    state.enemyMeta.delete(entity);
+    state.alienEntities.delete(entity);
+    state.wave.enemies.delete(entity);
+    entities.destroy(entity);
+  };
+
+  const registerEnemy = (entity: Entity, meta: EnemyMeta): void => {
+    state.enemyMeta.set(entity, meta);
+    if (meta.wave !== undefined) state.wave.enemies.add(entity);
+  };
+
+  const clearEnemies = (): void => {
+    const ids = Array.from(state.enemyMeta.keys());
+    for (let i = 0; i < ids.length; i += 1) destroyEntity(ids[i]!);
+    state.enemyMeta.clear();
+    state.wave.enemies.clear();
+    state.alienEntities.clear();
+  };
+
+  return { destroyEntity, registerEnemy, clearEnemies };
+}

--- a/src/game/spawn/pickups.ts
+++ b/src/game/spawn/pickups.ts
@@ -1,0 +1,132 @@
+import { ComponentStore } from '../../core/ecs/components';
+import { EntityRegistry, type Entity } from '../../core/ecs/entities';
+import type { Transform } from '../components/Transform';
+import type { Pickup } from '../components/Pickup';
+import type { GameState } from '../app/state';
+import { startPickupCrane, type PickupCraneSoundHandle } from '../../core/audio/sfx';
+import type { AudioBus } from '../../core/audio/audio';
+import type { PickupSite, SurvivorSite } from '../scenarios/layouts';
+
+export interface PickupStores {
+  transforms: ComponentStore<Transform>;
+  pickups: ComponentStore<Pickup>;
+}
+
+export interface PickupFactoryDeps {
+  entities: EntityRegistry;
+  stores: PickupStores;
+  state: GameState;
+  bus: AudioBus;
+  destroyEntity: (entity: Entity) => void;
+}
+
+export function createPickupFactory({
+  entities,
+  stores,
+  state,
+  bus,
+  destroyEntity,
+}: PickupFactoryDeps): {
+  spawnPickupEntity: (site: PickupSite) => Entity;
+  spawnPickups: (sites: PickupSite[]) => void;
+  spawnSurvivors: (sites: SurvivorSite[]) => void;
+  clearPickups: () => void;
+  beginPickupCraneSound: (entity: Entity, pickup: Pickup) => void;
+  cancelPickupCraneSound: (entity: Entity) => void;
+  completePickupCraneSound: (entity: Entity) => void;
+} {
+  const beginPickupCraneSound = (entity: Entity, pickup: Pickup): void => {
+    if (state.pickupCraneSounds.has(entity)) return;
+    const handle = startPickupCrane(bus, pickup.duration);
+    state.pickupCraneSounds.set(entity, handle);
+  };
+
+  const stopCraneHandle = (
+    entity: Entity,
+    action: (handle: PickupCraneSoundHandle) => void,
+  ): void => {
+    const handle = state.pickupCraneSounds.get(entity);
+    if (!handle) return;
+    action(handle);
+    state.pickupCraneSounds.delete(entity);
+  };
+
+  const cancelPickupCraneSound = (entity: Entity): void => {
+    stopCraneHandle(entity, (handle) => handle.cancel());
+  };
+
+  const completePickupCraneSound = (entity: Entity): void => {
+    stopCraneHandle(entity, (handle) => handle.complete());
+  };
+
+  const spawnPickupEntity = (site: PickupSite): Entity => {
+    const entity = entities.create();
+    stores.transforms.set(entity, { tx: site.tx, ty: site.ty, rot: 0 });
+    stores.pickups.set(entity, {
+      kind: site.kind,
+      radius: site.radius ?? 0.9,
+      duration: site.duration ?? 1.3,
+      fuelAmount: site.kind === 'fuel' ? (site.fuelAmount ?? 50) : undefined,
+      ammo:
+        site.kind === 'ammo'
+          ? {
+              missiles: site.ammo?.missiles ?? 80,
+              rockets: site.ammo?.rockets ?? 3,
+              hellfires: site.ammo?.hellfires ?? 0,
+            }
+          : undefined,
+      armorAmount: site.kind === 'armor' ? (site.armorAmount ?? 35) : undefined,
+      collectingBy: null,
+      progress: 0,
+    });
+    state.pickupEntities.push(entity);
+    return entity;
+  };
+
+  const spawnPickups = (sites: PickupSite[]): void => {
+    clearPickups();
+    for (let i = 0; i < sites.length; i += 1) {
+      spawnPickupEntity(sites[i]!);
+    }
+  };
+
+  const spawnSurvivors = (sites: SurvivorSite[]): void => {
+    if (state.rescue.survivorsSpawned) return;
+    state.rescue.survivorsSpawned = true;
+    for (let i = 0; i < sites.length; i += 1) {
+      const site = sites[i]!;
+      const entity = entities.create();
+      stores.transforms.set(entity, { tx: site.tx, ty: site.ty, rot: 0 });
+      stores.pickups.set(entity, {
+        kind: 'survivor',
+        radius: site.radius ?? 0.9,
+        duration: site.duration ?? 1.6,
+        fuelAmount: undefined,
+        ammo: undefined,
+        survivorCount: site.count,
+        collectingBy: null,
+        progress: 0,
+      });
+      state.pickupEntities.push(entity);
+      state.survivorEntities.push(entity);
+    }
+  };
+
+  const clearPickups = (): void => {
+    for (let i = state.pickupEntities.length - 1; i >= 0; i -= 1) {
+      destroyEntity(state.pickupEntities[i]!);
+    }
+    state.pickupEntities.length = 0;
+    state.survivorEntities.length = 0;
+  };
+
+  return {
+    spawnPickupEntity,
+    spawnPickups,
+    spawnSurvivors,
+    clearPickups,
+    beginPickupCraneSound,
+    cancelPickupCraneSound,
+    completePickupCraneSound,
+  };
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,264 +1,55 @@
 import { GameLoop } from './core/time/loop';
-import { InputManager } from './core/input/input';
-import { DebugOverlay } from './render/debug/overlay';
-import { parseTiled, type RuntimeTilemap } from './world/tiles/tiled';
-import { IsoTilemapRenderer } from './render/draw/tilemap';
-import { isoMapBounds, tileToIso, screenToApproxTile } from './render/iso/projection';
-import { Camera2D } from './render/camera/camera';
-import { ParallaxSky } from './render/draw/parallax';
-import sampleMapJson from './world/tiles/sample_map.json';
-import oceanMapJson from './world/tiles/ocean_map.json';
-import { EntityRegistry, type Entity } from './core/ecs/entities';
-import { ComponentStore } from './core/ecs/components';
-import type { Transform } from './game/components/Transform';
-import type { Physics } from './game/components/Physics';
-import type { Fuel } from './game/components/Fuel';
-import type { Sprite } from './game/components/Sprite';
-import { SystemScheduler } from './core/ecs/systems';
-import { MovementSystem } from './game/systems/Movement';
-import { RotorSpinSystem } from './game/systems/RotorSpin';
-import { FuelDrainSystem } from './game/systems/FuelDrain';
-import { drawHeli, drawPad } from './render/sprites/heli';
-import { drawBuilding } from './render/sprites/buildings';
-import {
-  drawSafeHouse,
-  getSafeHouseDoorIso,
-  type SafeHouseParams,
-} from './render/sprites/safehouse';
-import { drawRescueRunner } from './render/sprites/rescuees';
-import { WeaponFireSystem, type FireEvent } from './game/systems/WeaponFire';
-import type { Ammo } from './game/components/Ammo';
-import type { WeaponHolder } from './game/components/Weapon';
-import { RNG } from './core/util/rng';
-import { ProjectilePool } from './game/systems/Projectile';
-import type { AAA, SAM, PatrolDrone, ChaserDrone } from './game/components/AI';
-import { AIControlSystem } from './game/systems/AIControl';
-import { EnemyBehaviorSystem } from './game/systems/EnemyBehavior';
-import {
-  drawAAATurret,
-  drawSAM,
-  drawPatrolDrone,
-  drawChaserDrone,
-  drawAlienMonstrosity,
-  drawSpeedboat,
-} from './render/sprites/targets';
-import { Menu } from './ui/menus/menu';
-import { createUIStore, type UIStore } from './ui/menus/scenes';
-import { renderSettings, renderAchievements, renderAbout } from './ui/menus/renderers';
-import { FogOfWar } from './render/draw/fog';
-import { DamageSystem } from './game/systems/Damage';
+import { saveJson } from './core/util/storage';
+import { bootstrapApp } from './game/app/bootstrap';
+import { createGameState } from './game/app/state';
+import { createGameSceneRenderer } from './render/scene/gameScene';
+import { createEntityLifecycle } from './game/spawn/lifecycle';
+import { createBuildingFactory } from './game/spawn/buildings';
+import { createPickupFactory } from './game/spawn/pickups';
+import { createEnemyFactory } from './game/spawn/enemies';
 import { MissionTracker } from './game/missions/tracker';
+import { createMissionCoordinator } from './game/missions/coordinator';
+import { createUIController } from './game/app/update/ui';
+import { createPlayerController } from './game/app/update/player';
+import { createPickupProcessor } from './game/app/update/pickups';
+import { createCombatProcessor } from './game/app/update/combat';
 import { loadMission } from './game/missions/loader';
-import type { MissionDef, ObjectiveState } from './game/missions/types';
 import missionJson from './game/data/missions/sample_mission.json';
-import oceanMissionJson from './game/data/missions/ocean_mission.json';
-import type { Health } from './game/components/Health';
-import type { Collider } from './game/components/Collider';
-import type { Building } from './game/components/Building';
-import type { Pickup } from './game/components/Pickup';
-import type { Speedboat } from './game/components/Speedboat';
-import { drawHUD } from './ui/hud/hud';
-import { loadJson, saveJson, removeKey } from './core/util/storage';
-import { loadBindings, isDown } from './ui/input-remap/bindings';
-import { AudioBus } from './core/audio/audio';
-import {
-  EngineSound,
-  playMissile,
-  playRocket,
-  playHellfire,
-  playExplosion,
-  startPickupCrane,
-  type PickupCraneSoundHandle,
-} from './core/audio/sfx';
-import { CameraShake } from './render/camera/shake';
-import { getCanvasViewMetrics } from './render/canvas/metrics';
-import { drawPickupCrate } from './render/sprites/pickups';
-import { SpeedboatBehaviorSystem } from './game/systems/SpeedboatBehavior';
-import {
-  createMissionOneLayout,
-  createMissionTwoLayout,
-  cloneBuildingSite,
-  clonePadConfig,
-  clonePickupSite,
-  clonePoint,
-  cloneSafeHouseParams,
-  cloneSurvivorSite,
-  type PadConfig,
-  type BuildingSite,
-  type PickupSite,
-  type SurvivorSite,
-  type BoatLane,
-  type BoatWave,
-} from './game/scenarios/layouts';
+import type { MissionDef } from './game/missions/types';
 
-interface EnemyMeta {
-  kind: 'aaa' | 'sam' | 'patrol' | 'chaser' | 'speedboat';
-  score: number;
-  wave?: number;
-}
+const bootstrap = bootstrapApp();
+const state = createGameState();
 
-interface BuildingMeta {
-  score: number;
-  drop?: { kind: 'armor'; amount: number };
-  category: 'campus' | 'stronghold' | 'civilian';
-  triggersAlarm: boolean;
-}
-
-type ObjectiveLabelFn = (objective: ObjectiveState) => string;
-
-interface ScenarioConfig {
-  map: RuntimeTilemap;
-  pad: PadConfig;
-  safeHouse: SafeHouseParams;
-  campusSites: BuildingSite[];
-  civilianGenerator?: () => BuildingSite[];
-  staticStructures?: BuildingSite[];
-  pickupSites: PickupSite[];
-  survivorSites: SurvivorSite[];
-  alienSpawnPoints: Array<{ tx: number; ty: number }>;
-  waveSpawnPoints: Array<{ tx: number; ty: number }>;
-  initialWaveCountdown?: number;
-  waveCooldown?: (index: number) => number;
-  waveSpawner?: (index: number) => boolean;
-  setupMissionHandlers: () => void;
-  setupObjectiveLabels: () => void;
-  onApply?: () => void;
-  onReset?: () => void;
-  spawnExtraEnemies?: () => void;
-}
-
-interface BoatScenarioConfig {
-  lanes: BoatLane[];
-  waves: BoatWave[];
-  maxEscapes: number;
-  nextWaveDelay: number;
-}
-
-interface Explosion {
-  tx: number;
-  ty: number;
-  age: number;
-  duration: number;
-  radius: number;
-}
-
-interface RescueRunner {
-  startIso: { x: number; y: number };
-  endIso: { x: number; y: number };
-  progress: number;
-  delay: number;
-  duration: number;
-  elapsed: number;
-  bobOffset: number;
-}
-
-interface WaveState {
-  index: number;
-  countdown: number;
-  active: boolean;
-  timeInWave: number;
-  enemies: Set<Entity>;
-}
-
-interface PlayerState {
-  lives: number;
-  respawnTimer: number;
-  invulnerable: boolean;
-}
-
-const canvas = document.getElementById('game') as HTMLCanvasElement | null;
-if (!canvas) throw new Error('Canvas element with id "game" not found');
-const context = canvas.getContext('2d');
-if (!context) throw new Error('Failed to get 2D context');
-
-// Disable right-click context menu on the game canvas only
-canvas.addEventListener('contextmenu', (e) => {
-  e.preventDefault();
-});
-
-function resizeCanvasToDisplaySize(): void {
-  const dpr = Math.max(1, window.devicePixelRatio || 1);
-  const displayWidth = Math.floor(canvas.clientWidth * dpr);
-  const displayHeight = Math.floor(canvas.clientHeight * dpr);
-  if (canvas.width !== displayWidth || canvas.height !== displayHeight) {
-    canvas.width = displayWidth;
-    canvas.height = displayHeight;
-  }
-  context.setTransform(dpr, 0, 0, dpr, 0, 0);
-}
-window.addEventListener('resize', resizeCanvasToDisplaySize);
-resizeCanvasToDisplaySize();
-
-const input = new InputManager();
-input.attach(window);
-
-const debug = new DebugOverlay();
-window.addEventListener('keydown', (e) => {
-  if (e.key === '`' || e.key === '~') debug.toggle();
-});
-
-const ui: UIStore = loadJson<UIStore>('choppa:ui', createUIStore());
-ui.state = 'title';
-const titleMenu = new Menu([
-  { id: 'start', label: 'Start Mission' },
-  { id: 'settings', label: 'Settings' },
-  { id: 'achievements', label: 'Achievements' },
-  { id: 'about', label: 'About' },
-]);
-const bindings = loadBindings();
-
-const renderer = new IsoTilemapRenderer();
-const camera = new Camera2D({ deadzoneWidth: 160, deadzoneHeight: 120, lerp: 0.12 });
-const sky = new ParallaxSky();
-const fog = new FogOfWar();
-const bus = new AudioBus({
-  masterVolume: ui.settings.masterVolume,
-  musicVolume: ui.settings.musicVolume,
-  sfxVolume: ui.settings.sfxVolume,
-});
-const engine = new EngineSound(bus);
-const shake = new CameraShake();
-const entities = new EntityRegistry();
-const transforms = new ComponentStore<Transform>();
-const physics = new ComponentStore<Physics>();
-const fuels = new ComponentStore<Fuel>();
-const sprites = new ComponentStore<Sprite>();
-const ammos = new ComponentStore<Ammo>();
-const weapons = new ComponentStore<WeaponHolder>();
-const aaas = new ComponentStore<AAA>();
-const sams = new ComponentStore<SAM>();
-const patrols = new ComponentStore<PatrolDrone>();
-const chasers = new ComponentStore<ChaserDrone>();
-const healths = new ComponentStore<Health>();
-const colliders = new ComponentStore<Collider>();
-const buildings = new ComponentStore<Building>();
-const pickups = new ComponentStore<Pickup>();
-const speedboats = new ComponentStore<Speedboat>();
-
-// Use mission-specific tilemaps so level transitions can swap maps at runtime.
-const missionTilemaps: Record<string, RuntimeTilemap> = {
-  m01: parseTiled(sampleMapJson as unknown),
-  m02: parseTiled(oceanMapJson as unknown),
-};
-
-let runtimeMap: RuntimeTilemap = missionTilemaps.m01;
-let isoParams = { tileWidth: runtimeMap.tileWidth, tileHeight: runtimeMap.tileHeight };
-
-const missionOneLayout = createMissionOneLayout(missionTilemaps.m01);
-const missionTwoLayout = createMissionTwoLayout();
-let pad: PadConfig = clonePadConfig(missionOneLayout.pad);
-
-let safeHouse: SafeHouseParams = cloneSafeHouseParams(missionOneLayout.safeHouse);
-
-fog.configure(runtimeMap.width, runtimeMap.height);
+const {
+  canvas,
+  context,
+  resizeCanvasToDisplaySize,
+  input,
+  debug,
+  ui,
+  titleMenu,
+  bindings,
+  renderer,
+  camera,
+  sky,
+  fog,
+  audio,
+  shake,
+  entities,
+  stores,
+  scheduler,
+  rng,
+  projectilePool,
+  fireEvents,
+  weaponFire,
+  damage,
+  setPlayerLocator,
+  setBoatLandingHandler,
+} = bootstrap;
 
 const player = entities.create();
-transforms.set(player, {
-  tx: runtimeMap.width / 2,
-  ty: runtimeMap.height / 2,
-  rot: 0,
-});
-physics.set(player, {
+stores.transforms.set(player, { tx: 0, ty: 0, rot: 0 });
+stores.physics.set(player, {
   vx: 0,
   vy: 0,
   ax: 0,
@@ -267,9 +58,9 @@ physics.set(player, {
   maxSpeed: 4.2,
   turnRate: Math.PI * 2,
 });
-fuels.set(player, { current: 65, max: 100 });
-sprites.set(player, { color: '#92ffa6', rotor: 0 });
-ammos.set(player, {
+stores.fuels.set(player, { current: 65, max: 100 });
+stores.sprites.set(player, { color: '#92ffa6', rotor: 0 });
+stores.ammos.set(player, {
   missiles: 200,
   missilesMax: 200,
   rockets: 12,
@@ -277,1583 +68,285 @@ ammos.set(player, {
   hellfires: 2,
   hellfiresMax: 2,
 });
-weapons.set(player, {
+stores.weapons.set(player, {
   active: 'missile',
   cooldownMissile: 0,
   cooldownRocket: 0,
   cooldownHellfire: 0,
 });
-healths.set(player, { current: 100, max: 100 });
-colliders.set(player, { radius: 0.4, team: 'player' });
+stores.healths.set(player, { current: 100, max: 100 });
+stores.colliders.set(player, { radius: 0.4, team: 'player' });
 
-const scheduler = new SystemScheduler();
-const rng = new RNG(1337);
-const projectilePool = new ProjectilePool();
-const fireEvents: FireEvent[] = [];
-const weaponFire = new WeaponFireSystem(transforms, physics, weapons, ammos, fireEvents, rng);
-const damage = new DamageSystem(transforms, colliders, healths);
-interface MissionProgressData {
-  current?: string;
-  unlocked?: string;
-  lastWin?: number;
-  mission?: string; // legacy field
-}
+state.playerId = player;
 
-const missionDefs: MissionDef[] = [missionJson as MissionDef, oceanMissionJson as MissionDef];
-
-function findMissionIndex(id?: string): number {
-  if (!id) return -1;
-  return missionDefs.findIndex((def) => def.id === id);
-}
-
-const savedProgress = loadJson<MissionProgressData>('choppa:progress', {});
-let currentMissionIndex = findMissionIndex(savedProgress.current);
-if (currentMissionIndex < 0) {
-  currentMissionIndex = findMissionIndex(savedProgress.mission);
-}
-if (currentMissionIndex < 0) currentMissionIndex = 0;
-
-let highestUnlockedMissionIndex = findMissionIndex(savedProgress.unlocked);
-if (highestUnlockedMissionIndex < 0) {
-  const legacyIndex = findMissionIndex(savedProgress.mission);
-  if (legacyIndex >= 0)
-    highestUnlockedMissionIndex = Math.min(legacyIndex + 1, missionDefs.length - 1);
-}
-if (highestUnlockedMissionIndex < 0) highestUnlockedMissionIndex = currentMissionIndex;
-highestUnlockedMissionIndex = Math.max(highestUnlockedMissionIndex, currentMissionIndex);
-
-let nextMissionIndex = Math.min(currentMissionIndex + 1, highestUnlockedMissionIndex);
-const missionProgress: MissionProgressData = {
-  current: missionDefs[currentMissionIndex]?.id ?? missionDefs[0]?.id,
-  unlocked: missionDefs[highestUnlockedMissionIndex]?.id ?? missionDefs[0]?.id,
-  lastWin: savedProgress.lastWin,
-};
-
-function persistMissionProgress(): void {
-  saveJson('choppa:progress', missionProgress);
-}
-
-let missionDef: MissionDef = missionDefs[currentMissionIndex];
-let missionState = loadMission(missionDef);
 const missionHandlers: Record<string, () => boolean> = {};
-const mission = new MissionTracker(
-  missionState,
-  transforms,
-  colliders,
-  healths,
-  () => ({
-    tx: transforms.get(player)!.tx,
-    ty: transforms.get(player)!.ty,
-  }),
+const missionTracker = new MissionTracker(
+  loadMission(missionJson as MissionDef),
+  stores.transforms,
+  stores.colliders,
+  stores.healths,
+  () => {
+    const transform = stores.transforms.get(player);
+    return transform ? { tx: transform.tx, ty: transform.ty } : { tx: 0, ty: 0 };
+  },
   missionHandlers,
 );
-let missionBriefingInfo = createMissionBriefing(missionDef);
 
-scheduler.add(new MovementSystem(transforms, physics));
-scheduler.add(new RotorSpinSystem(sprites));
-scheduler.add(new FuelDrainSystem(fuels));
-scheduler.add(weaponFire);
-scheduler.add(
-  new AIControlSystem(transforms, aaas, sams, fireEvents, rng, () => ({
-    x: transforms.get(player)!.tx,
-    y: transforms.get(player)!.ty,
-  })),
-);
-scheduler.add(
-  new EnemyBehaviorSystem(transforms, physics, patrols, chasers, fireEvents, rng, () => ({
-    x: transforms.get(player)!.tx,
-    y: transforms.get(player)!.ty,
-  })),
-);
-scheduler.add(
-  new SpeedboatBehaviorSystem(
-    transforms,
-    physics,
-    speedboats,
-    fireEvents,
-    rng,
-    () => ({
-      x: transforms.get(player)!.tx,
-      y: transforms.get(player)!.ty,
-    }),
-    handleBoatLanding,
-  ),
-);
+const lifecycle = createEntityLifecycle({ entities, stores, state });
+const { destroyEntity, registerEnemy, clearEnemies } = lifecycle;
 
-const playerState: PlayerState = { lives: 3, respawnTimer: 0, invulnerable: false };
-const stats = { score: 0 };
-const explosions: Explosion[] = [];
-const enemyMeta = new Map<Entity, EnemyMeta>();
-const buildingMeta = new Map<Entity, BuildingMeta>();
-const waveState: WaveState = {
-  index: 0,
-  countdown: 3,
-  active: false,
-  timeInWave: 0,
-  enemies: new Set<Entity>(),
-};
-const minimapEnemies: { tx: number; ty: number }[] = [];
-const buildingEntities: Entity[] = [];
-const pickupEntities: Entity[] = [];
-const pickupCraneSounds = new Map<Entity, PickupCraneSoundHandle>();
-const survivorEntities: Entity[] = [];
-const alienEntities: Set<Entity> = new Set();
-const rescueRunners: RescueRunner[] = [];
-
-const SURVIVOR_CAPACITY = 4;
-
-const rescueState = {
-  carrying: 0,
-  rescued: 0,
-  total: 0,
-  survivorsSpawned: false,
-};
-
-let aliensTriggered = false;
-let aliensDefeated = false;
-let campusLeveled = false;
-
-let campusSites: BuildingSite[] = [];
-let civilianHouseSites: BuildingSite[] = [];
-let staticBuildingSites: BuildingSite[] = [];
-let buildingSites: BuildingSite[] = [];
-let pickupSites: PickupSite[] = [];
-let survivorSites: SurvivorSite[] = [];
-let alienSpawnPoints: { tx: number; ty: number }[] = [];
-let waveSpawnPoints: { tx: number; ty: number }[] = [];
-let extraStructureGenerator: (() => BuildingSite[]) | null = null;
-let spawnWaveHandler: ((index: number) => boolean) | null = null;
-let computeWaveCooldown: ((index: number) => number) | null = null;
-let initialWaveCountdown = 3.5;
-let scenarioOnReset: (() => void) | null = null;
-let spawnExtraScenarioEnemies: (() => void) | null = null;
-let objectiveLabelOverrides: Record<string, ObjectiveLabelFn> = {};
-
-let boatScenario: BoatScenarioConfig | null = null;
-let boatsEscaped = 0;
-let boatObjectiveComplete = false;
-let boatObjectiveFailed = false;
-
-function generateMissionOneCivilianHouses(): BuildingSite[] {
-  const clusters = missionOneLayout.civilianClusters ?? [];
-  const palettes = [
-    { body: '#7c95a3', roof: '#2f3f4d', ruin: '#3b2b2b' },
-    { body: '#9a7c6a', roof: '#4c3324', ruin: '#3c2018' },
-    { body: '#7f8f6b', roof: '#39482f', ruin: '#32291d' },
-    { body: '#a08aa3', roof: '#3d2c4b', ruin: '#352139' },
-  ];
-  const houses: BuildingSite[] = [];
-  for (let c = 0; c < clusters.length; c += 1) {
-    const cluster = clusters[c]!;
-    for (let i = 0; i < cluster.count; i += 1) {
-      const paletteRawIndex = Math.floor(rng.range(0, palettes.length));
-      const paletteIndex = Math.min(palettes.length - 1, paletteRawIndex);
-      const palette = palettes[paletteIndex]!;
-      houses.push({
-        tx: cluster.tx + rng.range(-cluster.spread, cluster.spread),
-        ty: cluster.ty + rng.range(-cluster.spread, cluster.spread),
-        width: 0.95 + rng.range(-0.1, 0.25),
-        depth: 0.95 + rng.range(-0.18, 0.2),
-        height: 18 + rng.range(-2, 4),
-        health: 60 + rng.range(-8, 10),
-        colliderRadius: 0.6 + rng.range(-0.04, 0.08),
-        bodyColor: palette.body,
-        roofColor: palette.roof,
-        ruinColor: palette.ruin,
-        score: 0,
-        category: 'civilian',
-        triggersAlarm: false,
-      });
-    }
-  }
-  if (houses.length > 0) {
-    const specialIndex = Math.min(houses.length - 1, Math.floor(rng.range(0, houses.length)));
-    houses[specialIndex] = {
-      ...houses[specialIndex]!,
-      drop: { kind: 'armor', amount: 35 },
-    };
-  }
-  return houses;
-}
-
-const missionTwoBoat = missionTwoLayout.boat;
-
-const scenarioConfigs: Record<string, ScenarioConfig> = {
-  m01: {
-    map: missionTilemaps.m01,
-    pad: missionOneLayout.pad,
-    safeHouse: missionOneLayout.safeHouse,
-    campusSites: missionOneLayout.campusSites,
-    civilianGenerator: generateMissionOneCivilianHouses,
-    pickupSites: missionOneLayout.pickupSites,
-    survivorSites: missionOneLayout.survivorSites,
-    alienSpawnPoints: missionOneLayout.alienSpawnPoints,
-    waveSpawnPoints: missionOneLayout.waveSpawnPoints,
-    initialWaveCountdown: 3.5,
-    waveCooldown: defaultWaveCooldown,
-    waveSpawner: spawnDefaultWave,
-    setupMissionHandlers: setupMissionOneHandlers,
-    setupObjectiveLabels: setupMissionOneObjectiveLabels,
-    onApply: () => {
-      boatScenario = null;
-      boatsEscaped = 0;
-      boatObjectiveComplete = false;
-      boatObjectiveFailed = false;
-    },
+const { spawnBuildings, spawnAlienStronghold } = createBuildingFactory({
+  entities,
+  stores: {
+    transforms: stores.transforms,
+    buildings: stores.buildings,
+    healths: stores.healths,
+    colliders: stores.colliders,
   },
-  m02: {
-    map: missionTilemaps.m02,
-    pad: missionTwoLayout.pad,
-    safeHouse: missionTwoLayout.safeHouse,
-    campusSites: missionTwoLayout.campusSites,
-    staticStructures: missionTwoLayout.staticStructures,
-    pickupSites: missionTwoLayout.pickupSites,
-    survivorSites: missionTwoLayout.survivorSites,
-    alienSpawnPoints: missionTwoLayout.alienSpawnPoints,
-    waveSpawnPoints: missionTwoLayout.waveSpawnPoints,
-    initialWaveCountdown: 4.5,
-    waveCooldown: boatWaveCooldown,
-    waveSpawner: spawnBoatWave,
-    setupMissionHandlers: setupMissionTwoHandlers,
-    setupObjectiveLabels: setupMissionTwoObjectiveLabels,
-    onApply: () => {
-      activateBoatScenario();
-    },
-    onReset: () => {
-      boatsEscaped = 0;
-      boatObjectiveComplete = false;
-      boatObjectiveFailed = false;
-    },
-    spawnExtraEnemies: spawnMissionTwoGuards,
+  state,
+  destroyEntity,
+});
+
+const {
+  spawnPickupEntity,
+  spawnPickups,
+  spawnSurvivors,
+  beginPickupCraneSound,
+  cancelPickupCraneSound,
+  completePickupCraneSound,
+} = createPickupFactory({
+  entities,
+  stores: {
+    transforms: stores.transforms,
+    pickups: stores.pickups,
   },
+  state,
+  bus: audio.bus,
+  destroyEntity,
+});
+
+const enemyFactory = createEnemyFactory({
+  entities,
+  stores: {
+    transforms: stores.transforms,
+    physics: stores.physics,
+    healths: stores.healths,
+    colliders: stores.colliders,
+    aaas: stores.aaas,
+    sams: stores.sams,
+    patrols: stores.patrols,
+    chasers: stores.chasers,
+    speedboats: stores.speedboats,
+  },
+  rng,
+  state,
+  registerEnemy,
+});
+const {
+  spawnMissionEnemies,
+  spawnCoastGuard,
+  spawnShorePatrol,
+  spawnSpeedboat,
+  spawnDefaultWave,
+  spawnBoatWave,
+  spawnAlienUnit,
+} = enemyFactory;
+
+const missionCoordinator = createMissionCoordinator({
+  rng,
+  state,
+  missionTracker,
+  missionHandlers,
+  enemySpawners: {
+    spawnMissionEnemies,
+    spawnCoastGuard,
+    spawnShorePatrol,
+    spawnSpeedboat,
+    spawnDefaultWave,
+    spawnBoatWave,
+  },
+  buildingSpawner: {
+    spawnAlienStronghold: (type, tx, ty, spawnUnit) =>
+      spawnAlienStronghold(type, tx, ty, spawnUnit),
+  },
+  spawnAlienUnit,
+});
+missionCoordinator.initMissions();
+
+let scenario = missionCoordinator.getScenario();
+let runtimeMap = scenario.map;
+let isoParams = scenario.isoParams;
+let pad = scenario.pad;
+let safeHouse = scenario.safeHouse;
+let missionBriefing = missionCoordinator.getBriefing();
+
+fog.configure(runtimeMap.width, runtimeMap.height);
+
+setPlayerLocator(() => {
+  const transform = stores.transforms.get(player);
+  return transform ? { x: transform.tx, y: transform.ty } : { x: 0, y: 0 };
+});
+
+const gameSceneRenderer = createGameSceneRenderer({
+  canvas,
+  context,
+  resizeCanvasToDisplaySize,
+  renderer,
+  camera,
+  sky,
+  fog,
+  shake,
+  projectilePool,
+  debug,
+});
+
+const playerController = createPlayerController({
+  state,
+  ui,
+  player,
+  transforms: stores.transforms,
+  physics: stores.physics,
+  fuels: stores.fuels,
+  ammos: stores.ammos,
+  healths: stores.healths,
+  colliders: stores.colliders,
+  weaponFire,
+  engine: audio.engine,
+  bindings,
+  camera,
+  context,
+  getStartPosition: () => missionCoordinator.mission.state.def.startPos,
+});
+
+const pickupProcessor = createPickupProcessor({
+  state,
+  player,
+  transforms: stores.transforms,
+  pickups: stores.pickups,
+  fuels: stores.fuels,
+  ammos: stores.ammos,
+  healths: stores.healths,
+  pickupFactory: {
+    beginPickupCraneSound,
+    cancelPickupCraneSound,
+    completePickupCraneSound,
+  },
+  destroyEntity,
+  rng,
+});
+
+const spawnPickupDrop = (tx: number, ty: number, amount: number): void => {
+  spawnPickupEntity({
+    tx,
+    ty,
+    kind: 'armor',
+    radius: 0.95,
+    duration: 1.4,
+    armorAmount: amount,
+  });
 };
 
-function createMissionBriefing(def: MissionDef): { title: string; text: string; goals: string[] } {
-  return {
-    title: def.title,
-    text: def.briefing,
-    goals: def.objectives.map((o) => o.name),
-  };
-}
+const combatProcessor = createCombatProcessor({
+  state,
+  ui,
+  player,
+  scheduler,
+  fireEvents,
+  projectilePool,
+  damage,
+  bus: audio.bus,
+  shake,
+  transforms: stores.transforms,
+  colliders: stores.colliders,
+  physics: stores.physics,
+  healths: stores.healths,
+  buildings: stores.buildings,
+  mission: missionCoordinator.mission,
+  missionCoordinator,
+  spawnSurvivors,
+  spawnPickupDrop,
+  destroyEntity,
+  engine: audio.engine,
+  spawnAlienUnit,
+});
 
-function defaultWaveCooldown(index: number): number {
-  return Math.max(3, 5 - index * 0.2);
-}
+setBoatLandingHandler(combatProcessor.handleBoatLanding);
 
-function boatWaveCooldown(index: number): number {
-  if (!boatScenario) return Number.POSITIVE_INFINITY;
-  return index < boatScenario.waves.length ? boatScenario.nextWaveDelay : Number.POSITIVE_INFINITY;
-}
+const resetGame = (targetMissionIndex?: number): void => {
+  const { current, highestUnlocked } = missionCoordinator.getMissionIndices();
+  const clamped = Math.min(targetMissionIndex ?? current, highestUnlocked);
 
-function regenerateWorldStructures(): void {
-  civilianHouseSites = extraStructureGenerator ? extraStructureGenerator() : [];
-  buildingSites = [...campusSites];
-  if (civilianHouseSites.length > 0) buildingSites.push(...civilianHouseSites);
-  if (staticBuildingSites.length > 0) buildingSites.push(...staticBuildingSites);
-}
+  missionCoordinator.setMission(clamped);
+  scenario = missionCoordinator.getScenario();
+  runtimeMap = scenario.map;
+  isoParams = scenario.isoParams;
+  pad = scenario.pad;
+  safeHouse = scenario.safeHouse;
+  missionBriefing = missionCoordinator.getBriefing();
 
-function applyScenario(id: string): void {
-  const config = scenarioConfigs[id];
-  if (!config) throw new Error(`Unknown mission scenario: ${id}`);
-  runtimeMap = config.map;
-  isoParams = { tileWidth: runtimeMap.tileWidth, tileHeight: runtimeMap.tileHeight };
   fog.configure(runtimeMap.width, runtimeMap.height);
-  const playerTransform = transforms.get(player);
-  if (playerTransform) {
-    playerTransform.tx = mission.state.def.startPos.tx;
-    playerTransform.ty = mission.state.def.startPos.ty;
-  }
-  pad = clonePadConfig(config.pad);
-  safeHouse = cloneSafeHouseParams(config.safeHouse);
-  campusSites = config.campusSites.map((site) => cloneBuildingSite(site));
-  extraStructureGenerator = config.civilianGenerator ?? null;
-  staticBuildingSites = config.staticStructures
-    ? config.staticStructures.map((site) => cloneBuildingSite(site))
-    : [];
-  pickupSites = config.pickupSites.map((site) => clonePickupSite(site));
-  survivorSites = config.survivorSites.map((site) => cloneSurvivorSite(site));
-  alienSpawnPoints = config.alienSpawnPoints.map((point) => clonePoint(point));
-  waveSpawnPoints = config.waveSpawnPoints.map((point) => clonePoint(point));
-  spawnWaveHandler = config.waveSpawner ?? spawnDefaultWave;
-  computeWaveCooldown = config.waveCooldown ?? defaultWaveCooldown;
-  initialWaveCountdown = config.initialWaveCountdown ?? 3.5;
-  scenarioOnReset = config.onReset ?? null;
-  spawnExtraScenarioEnemies = config.spawnExtraEnemies ?? null;
-  objectiveLabelOverrides = {};
-  for (const key of Object.keys(missionHandlers)) delete missionHandlers[key];
-  if (config.onApply) config.onApply();
-  regenerateWorldStructures();
-  rescueState.carrying = 0;
-  rescueState.rescued = 0;
-  rescueState.total = survivorSites.reduce((sum, site) => sum + site.count, 0);
-  rescueState.survivorsSpawned = false;
-  aliensTriggered = false;
-  aliensDefeated = false;
-  campusLeveled = false;
-  config.setupMissionHandlers();
-  config.setupObjectiveLabels();
-  waveState.index = 0;
-  waveState.countdown = initialWaveCountdown;
-  waveState.active = false;
-  waveState.timeInWave = 0;
-  waveState.enemies.clear();
-}
 
-function setMission(index: number): void {
-  const clampedIndex = Math.min(Math.max(index, 0), missionDefs.length - 1);
-  currentMissionIndex = clampedIndex;
-  if (highestUnlockedMissionIndex < currentMissionIndex) {
-    highestUnlockedMissionIndex = currentMissionIndex;
-  }
-  missionDef = missionDefs[currentMissionIndex];
-  missionState = loadMission(missionDef);
-  mission.state = missionState;
-  missionBriefingInfo = createMissionBriefing(missionDef);
-  applyScenario(missionDef.id);
-  nextMissionIndex = Math.min(currentMissionIndex + 1, highestUnlockedMissionIndex);
-  missionProgress.current = missionDefs[currentMissionIndex]?.id ?? missionProgress.current;
-  missionProgress.unlocked =
-    missionDefs[highestUnlockedMissionIndex]?.id ?? missionProgress.unlocked;
-  persistMissionProgress();
-}
+  clearEnemies();
+  projectilePool.clear();
+  damage.reset();
+  state.explosions.length = 0;
+  state.minimapEnemies.length = 0;
+  state.rescueRunners.length = 0;
 
-function setupMissionOneHandlers(): void {
-  missionHandlers.obj4 = () => aliensTriggered && aliensDefeated;
-  missionHandlers.obj5 = () => rescueState.rescued >= rescueState.total;
-}
+  spawnBuildings(scenario.buildingSites);
+  spawnPickups(scenario.pickupSites);
+  missionCoordinator.spawnMissionEnemies();
 
-function setupMissionOneObjectiveLabels(): void {
-  objectiveLabelOverrides.obj4 = (objective) => {
-    if (!aliensTriggered) return `${objective.name} (stand by)`;
-    if (!objective.complete) return `${objective.name} (${alienEntities.size} remaining)`;
-    return objective.name;
-  };
-  objectiveLabelOverrides.obj5 = (objective) => {
-    const carrying = rescueState.carrying;
-    let label = `${objective.name} (${rescueState.rescued}/${rescueState.total}`;
-    if (carrying > 0) label += ` +${carrying}`;
-    label += ')';
-    return label;
-  };
-}
+  state.stats.score = 0;
+  state.player.lives = 3;
+  state.player.respawnTimer = 0;
+  state.player.invulnerable = false;
+  state.rescue.carrying = 0;
+  state.rescue.rescued = 0;
+  state.rescue.total = scenario.survivorSites.reduce((sum, site) => sum + site.count, 0);
+  state.rescue.survivorsSpawned = false;
+  state.boat.boatsEscaped = 0;
+  state.boat.objectiveComplete = false;
+  state.boat.objectiveFailed = false;
+  state.wave.index = 0;
+  state.wave.countdown = scenario.initialWaveCountdown;
+  state.wave.active = false;
+  state.wave.timeInWave = 0;
+  state.wave.enemies.clear();
+  state.pickupCraneSounds.forEach((handle) => handle.cancel());
+  state.pickupCraneSounds.clear();
 
-function setupMissionTwoHandlers(): void {
-  missionHandlers.boats = () => boatObjectiveComplete && !boatObjectiveFailed;
-}
+  fog.reset();
+  playerController.resetPlayer();
 
-function setupMissionTwoObjectiveLabels(): void {
-  objectiveLabelOverrides.boats = (objective) => {
-    if (!boatScenario) return objective.name;
-    const totalWaves = boatScenario.waves.length;
-    const currentWave = waveState.active
-      ? waveState.index
-      : Math.min(waveState.index + 1, totalWaves);
-    let label = `${objective.name} (Escaped: ${boatsEscaped}/${boatScenario.maxEscapes}`;
-    if (!objective.complete) {
-      const clampedWave = Math.min(Math.max(currentWave, 1), totalWaves);
-      label += ` | Wave ${clampedWave} of ${totalWaves}`;
-      if (
-        !waveState.active &&
-        waveState.index < totalWaves &&
-        Number.isFinite(waveState.countdown)
-      ) {
-        label += ` | Next wave in: ${Math.max(0, waveState.countdown).toFixed(1)}s`;
-      }
-    }
-    label += ')';
-    return label;
-  };
-}
+  ui.state = 'briefing';
+};
 
-function spawnMissionTwoGuards(): void {
-  const guardPosts = missionTwoLayout.guardPosts ?? [];
-  for (let i = 0; i < guardPosts.length; i += 1) {
-    spawnCoastGuard(guardPosts[i]!, 9.2);
-  }
-  const patrolRoutes = missionTwoLayout.patrolRoutes ?? [];
-  for (let i = 0; i < patrolRoutes.length; i += 1) {
-    spawnShorePatrol(patrolRoutes[i]!);
-  }
-}
-
-function spawnCoastGuard(point: { tx: number; ty: number }, leashRange: number): void {
-  const entity = entities.create();
-  transforms.set(entity, { tx: point.tx, ty: point.ty, rot: 0 });
-  physics.set(entity, {
-    vx: 0,
-    vy: 0,
-    ax: 0,
-    ay: 0,
-    drag: 0.72,
-    maxSpeed: 3.4,
-    turnRate: Math.PI * 1.5,
-  });
-  healths.set(entity, { current: 38, max: 38 });
-  colliders.set(entity, { radius: 0.35, team: 'enemy' });
-  chasers.set(entity, {
-    speed: 3.1,
-    acceleration: 3.5,
-    fireRange: 6.5,
-    fireInterval: 1.05,
-    cooldown: 0,
-    spread: 0.2,
-    guard: {
-      homeX: point.tx,
-      homeY: point.ty,
-      holdRadius: 0.6,
-      aggroRange: 6.8,
-      leashRange,
-      alerted: false,
-    },
-  });
-  registerEnemy(entity, { kind: 'chaser', score: 250 });
-}
-
-function spawnShorePatrol(route: { tx: number; ty: number; axis: 'x' | 'y'; range: number }): void {
-  const entity = entities.create();
-  transforms.set(entity, { tx: route.tx, ty: route.ty, rot: 0 });
-  physics.set(entity, {
-    vx: 0,
-    vy: 0,
-    ax: 0,
-    ay: 0,
-    drag: 0.86,
-    maxSpeed: 2.3,
-    turnRate: Math.PI,
-  });
-  healths.set(entity, { current: 28, max: 28 });
-  colliders.set(entity, { radius: 0.38, team: 'enemy' });
-  patrols.set(entity, {
-    axis: route.axis,
-    originX: route.tx,
-    originY: route.ty,
-    range: route.range,
-    speed: 2.1,
-    direction: rng.float01() > 0.5 ? 1 : -1,
-    fireRange: 6.4,
-    fireInterval: 1.15,
-    cooldown: 0,
-  });
-  registerEnemy(entity, { kind: 'patrol', score: 165 });
-}
-
-function activateBoatScenario(): void {
-  if (!missionTwoBoat) {
-    boatScenario = null;
-    return;
-  }
-  boatScenario = {
-    lanes: missionTwoBoat.lanes.map((lane) => ({
-      entry: { ...lane.entry },
-      target: { ...lane.target },
-    })),
-    waves: missionTwoBoat.waves.map((wave) => ({ ...wave })),
-    maxEscapes: missionTwoBoat.maxEscapes,
-    nextWaveDelay: missionTwoBoat.nextWaveDelay,
-  };
-  boatsEscaped = 0;
-  boatObjectiveComplete = false;
-  boatObjectiveFailed = false;
-}
-
-function spawnSpeedboat(lane: BoatLane, wave: number): void {
-  const entity = entities.create();
-  const entryJitter = (rng.float01() - 0.5) * 0.6;
-  const entryJitterY = (rng.float01() - 0.5) * 0.4;
-  const cruiseSpeed = 2.4 + wave * 0.18;
-  transforms.set(entity, {
-    tx: lane.entry.tx + entryJitter,
-    ty: lane.entry.ty + entryJitterY,
-    rot: 0,
-  });
-  physics.set(entity, {
-    vx: 0,
-    vy: 0,
-    ax: 0,
-    ay: 0,
-    drag: 0.78,
-    maxSpeed: cruiseSpeed + 0.4,
-    turnRate: Math.PI,
-  });
-  healths.set(entity, { current: 24 + wave * 4, max: 24 + wave * 4 });
-  colliders.set(entity, { radius: 0.4, team: 'enemy' });
-  speedboats.set(entity, {
-    targetX: lane.target.tx + (rng.float01() - 0.5) * 0.5,
-    targetY: lane.target.ty + (rng.float01() - 0.5) * 0.5,
-    speed: cruiseSpeed,
-    acceleration: 2.6,
-    fireRange: 6.2,
-    fireInterval: Math.max(0.95, 1.3 - wave * 0.08),
-    cooldown: 0,
-    arrivalRadius: 0.6,
-    activationRange: 7.5,
-    activated: false,
-  });
-  registerEnemy(entity, { kind: 'speedboat', score: 220 + wave * 25, wave });
-}
-
-function spawnDefaultWave(index: number): boolean {
-  if (waveSpawnPoints.length === 0) return false;
-  waveState.enemies.clear();
-  const patrolCount = Math.min(waveSpawnPoints.length, 2 + index);
-  const chaserCount = Math.min(waveSpawnPoints.length, Math.max(0, Math.floor(index / 2)));
-  for (let i = 0; i < patrolCount; i += 1) {
-    const point = waveSpawnPoints[i % waveSpawnPoints.length]!;
-    const axis: 'x' | 'y' = i % 2 === 0 ? 'x' : 'y';
-    spawnPatrolEnemy(point, index, axis);
-  }
-  for (let i = 0; i < chaserCount; i += 1) {
-    const point = waveSpawnPoints[(i + patrolCount) % waveSpawnPoints.length]!;
-    spawnChaserEnemy(point, index);
-  }
-  return true;
-}
-
-function spawnBoatWave(index: number): boolean {
-  if (!boatScenario || boatScenario.lanes.length === 0) return false;
-  waveState.enemies.clear();
-  const waveDef = boatScenario.waves[index - 1];
-  if (!waveDef) return false;
-  const laneOffset = Math.floor(rng.range(0, boatScenario.lanes.length));
-  for (let i = 0; i < waveDef.count; i += 1) {
-    const lane = boatScenario.lanes[(i + laneOffset) % boatScenario.lanes.length]!;
-    spawnSpeedboat(lane, index);
-  }
-  return waveDef.count > 0;
-}
+const uiController = createUIController({
+  ui,
+  titleMenu,
+  bindings,
+  saveUI: (store) => saveJson('choppa:ui', store),
+  applyAudioSettings: (muted) => audio.applySettings(muted),
+  resetGame,
+  getNextMissionIndex: () => missionCoordinator.getMissionIndices().next,
+});
 
 let fps = 0;
 let frames = 0;
 let accumulator = 0;
 let lastStepDt = 1 / 60;
-let pauseLatch = false;
-let muteLatch = false;
-let audioMuted = false;
-function setAudioVolumes(): void {
-  bus.setMaster(audioMuted ? 0 : ui.settings.masterVolume);
-  bus.setMusic(ui.settings.musicVolume);
-  bus.setSfx(ui.settings.sfxVolume);
-}
-setAudioVolumes();
 
-function spawnExplosion(tx: number, ty: number, radius = 0.9, duration = 0.6): void {
-  explosions.push({ tx, ty, age: 0, duration, radius });
-}
-
-function updateExplosions(dt: number): void {
-  for (let i = explosions.length - 1; i >= 0; i -= 1) {
-    const e = explosions[i]!;
-    e.age += dt;
-    if (e.age >= e.duration) explosions.splice(i, 1);
-  }
-}
-
-function handleBoatLanding(entity: Entity): void {
-  if (!boatScenario) return;
-  const t = transforms.get(entity);
-  if (t) spawnExplosion(t.tx, t.ty, 1.1, 0.8);
-  playExplosion(bus, 0.8);
-  destroyEntity(entity);
-  boatsEscaped += 1;
-  if (ui.state === 'in-game' && boatsEscaped >= boatScenario.maxEscapes) {
-    boatObjectiveFailed = true;
-    ui.state = 'game-over';
-    waveState.active = false;
-    engine.stop();
-  }
-}
-
-function spawnRescueRunnerAnimation(count: number): void {
-  if (count <= 0) return;
-  const padOrigin = tileToIso(pad.tx - 0.05, pad.ty + 0.18, isoParams);
-  const doorIso = getSafeHouseDoorIso(isoParams, safeHouse);
-  for (let i = 0; i < count; i += 1) {
-    const jitterStartX = (rng.float01() - 0.5) * 10;
-    const jitterStartY = (rng.float01() - 0.5) * 6;
-    const jitterEndX = (rng.float01() - 0.5) * 3;
-    const jitterEndY = (rng.float01() - 0.5) * 2.4;
-    const delay = i * 0.16 + rng.float01() * 0.05;
-    const duration = 0.82 + rng.float01() * 0.32;
-    rescueRunners.push({
-      startIso: { x: padOrigin.x + jitterStartX, y: padOrigin.y + jitterStartY },
-      endIso: { x: doorIso.x + jitterEndX, y: doorIso.y + jitterEndY },
-      progress: 0,
-      delay,
-      duration,
-      elapsed: 0,
-      bobOffset: rng.float01() * Math.PI * 2,
-    });
-  }
-}
-
-function updateRescueRunnerAnimations(dt: number): void {
-  for (let i = rescueRunners.length - 1; i >= 0; i -= 1) {
-    const runner = rescueRunners[i]!;
-    if (runner.delay > 0) {
-      runner.delay -= dt;
-      if (runner.delay > 0) continue;
-      runner.delay = 0;
-    }
-    runner.elapsed += dt;
-    runner.progress += dt / runner.duration;
-    if (runner.progress >= 1.3) {
-      rescueRunners.splice(i, 1);
-    }
-  }
-}
-
-function beginPickupCraneSound(entity: Entity, pickup: Pickup): void {
-  if (pickupCraneSounds.has(entity)) return;
-  const handle = startPickupCrane(bus, pickup.duration);
-  pickupCraneSounds.set(entity, handle);
-}
-
-function cancelPickupCraneSound(entity: Entity): void {
-  const handle = pickupCraneSounds.get(entity);
-  if (!handle) return;
-  handle.cancel();
-  pickupCraneSounds.delete(entity);
-}
-
-function completePickupCraneSound(entity: Entity): void {
-  const handle = pickupCraneSounds.get(entity);
-  if (!handle) return;
-  handle.complete();
-  pickupCraneSounds.delete(entity);
-}
-
-function destroyEntity(entity: Entity): void {
-  if (entity === player) return;
-  cancelPickupCraneSound(entity);
-  transforms.remove(entity);
-  physics.remove(entity);
-  fuels.remove(entity);
-  sprites.remove(entity);
-  ammos.remove(entity);
-  weapons.remove(entity);
-  aaas.remove(entity);
-  sams.remove(entity);
-  patrols.remove(entity);
-  chasers.remove(entity);
-  speedboats.remove(entity);
-  healths.remove(entity);
-  colliders.remove(entity);
-  buildings.remove(entity);
-  pickups.remove(entity);
-  buildingMeta.delete(entity);
-  const buildingIndex = buildingEntities.indexOf(entity);
-  if (buildingIndex !== -1) buildingEntities.splice(buildingIndex, 1);
-  const pickupIndex = pickupEntities.indexOf(entity);
-  if (pickupIndex !== -1) pickupEntities.splice(pickupIndex, 1);
-  const survivorIndex = survivorEntities.indexOf(entity);
-  if (survivorIndex !== -1) survivorEntities.splice(survivorIndex, 1);
-  enemyMeta.delete(entity);
-  alienEntities.delete(entity);
-  waveState.enemies.delete(entity);
-  entities.destroy(entity);
-}
-
-function registerEnemy(entity: Entity, meta: EnemyMeta): void {
-  enemyMeta.set(entity, meta);
-  if (meta.wave !== undefined) waveState.enemies.add(entity);
-}
-
-function clearEnemies(): void {
-  const ids = Array.from(enemyMeta.keys());
-  for (let i = 0; i < ids.length; i += 1) destroyEntity(ids[i]!);
-  enemyMeta.clear();
-  waveState.enemies.clear();
-  alienEntities.clear();
-}
-
-function spawnMissionEnemies(): void {
-  if (!mission.state.def.enemySpawns) return;
-  for (let i = 0; i < mission.state.def.enemySpawns.length; i += 1) {
-    const spawn = mission.state.def.enemySpawns[i]!;
-    const entity = entities.create();
-    transforms.set(entity, { tx: spawn.at.tx, ty: spawn.at.ty, rot: 0 });
-    healths.set(entity, { current: 30, max: 30 });
-    colliders.set(entity, { radius: 0.5, team: 'enemy' });
-    if (spawn.type === 'AAA') {
-      aaas.set(entity, {
-        range: 8,
-        cooldown: 0,
-        fireInterval: 0.6,
-        projectileSpeed: 12,
-        spread: 0.06,
-      });
-      registerEnemy(entity, { kind: 'aaa', score: 150 });
-      spawnAlienStronghold('AAA', spawn.at.tx, spawn.at.ty);
-    } else {
-      sams.set(entity, {
-        range: 12,
-        lockTime: 0.8,
-        cooldown: 0,
-        fireInterval: 2.5,
-        turnRate: Math.PI * 0.7,
-        missileSpeed: 6,
-        lockProgress: 0,
-      });
-      registerEnemy(entity, { kind: 'sam', score: 200 });
-      spawnAlienStronghold('SAM', spawn.at.tx, spawn.at.ty);
-    }
-  }
-  if (spawnExtraScenarioEnemies) spawnExtraScenarioEnemies();
-}
-
-function clearBuildings(): void {
-  for (let i = buildingEntities.length - 1; i >= 0; i -= 1) {
-    const entity = buildingEntities[i]!;
-    destroyEntity(entity);
-  }
-  buildingEntities.length = 0;
-}
-
-function createBuildingEntity(site: BuildingSite): Entity {
-  const entity = entities.create();
-  transforms.set(entity, { tx: site.tx, ty: site.ty, rot: 0 });
-  buildings.set(entity, {
-    width: site.width,
-    depth: site.depth,
-    height: site.height,
-    bodyColor: site.bodyColor,
-    roofColor: site.roofColor,
-    ruinColor: site.ruinColor,
-  });
-  healths.set(entity, { current: site.health, max: site.health });
-  colliders.set(entity, { radius: site.colliderRadius, team: 'enemy' });
-  buildingMeta.set(entity, {
-    score: site.score ?? 0,
-    drop: site.drop,
-    category: site.category ?? 'civilian',
-    triggersAlarm: Boolean(site.triggersAlarm),
-  });
-  buildingEntities.push(entity);
-  return entity;
-}
-
-function spawnBuildings(): void {
-  clearBuildings();
-  for (let i = 0; i < buildingSites.length; i += 1) {
-    const site = buildingSites[i]!;
-    createBuildingEntity(site);
-  }
-}
-
-function spawnAlienStronghold(type: 'AAA' | 'SAM', tx: number, ty: number): void {
-  const strongholdStructures: BuildingSite[] =
-    type === 'AAA'
-      ? [
-          {
-            tx: tx - 0.85,
-            ty: ty + 0.55,
-            width: 1.15,
-            depth: 0.95,
-            height: 22,
-            health: 85,
-            colliderRadius: 0.7,
-            bodyColor: '#25143c',
-            roofColor: '#6efdd4',
-            ruinColor: '#341d4d',
-            score: 130,
-            category: 'stronghold',
-          },
-          {
-            tx: tx + 0.9,
-            ty: ty - 0.45,
-            width: 1.05,
-            depth: 0.85,
-            height: 20,
-            health: 80,
-            colliderRadius: 0.68,
-            bodyColor: '#28163f',
-            roofColor: '#63f0c8',
-            ruinColor: '#2f1744',
-            score: 130,
-            category: 'stronghold',
-          },
-          {
-            tx: tx,
-            ty: ty + 0.9,
-            width: 1.6,
-            depth: 0.6,
-            height: 16,
-            health: 70,
-            colliderRadius: 0.65,
-            bodyColor: '#1f0f32',
-            roofColor: '#8bf9e1',
-            ruinColor: '#2a123d',
-            score: 110,
-            category: 'stronghold',
-          },
-        ]
-      : [
-          {
-            tx: tx,
-            ty: ty - 0.95,
-            width: 1.6,
-            depth: 1.15,
-            height: 30,
-            health: 140,
-            colliderRadius: 0.88,
-            bodyColor: '#1f1d46',
-            roofColor: '#7afbe9',
-            ruinColor: '#261b3d',
-            score: 200,
-            category: 'stronghold',
-          },
-          {
-            tx: tx - 1.15,
-            ty: ty + 0.55,
-            width: 1.1,
-            depth: 0.9,
-            height: 24,
-            health: 90,
-            colliderRadius: 0.72,
-            bodyColor: '#261548',
-            roofColor: '#5cf3db',
-            ruinColor: '#2e1a4f',
-            score: 150,
-            category: 'stronghold',
-          },
-          {
-            tx: tx + 1.1,
-            ty: ty + 0.65,
-            width: 1.15,
-            depth: 0.95,
-            height: 24,
-            health: 90,
-            colliderRadius: 0.74,
-            bodyColor: '#2a184d',
-            roofColor: '#68f8e1',
-            ruinColor: '#311e53',
-            score: 150,
-            category: 'stronghold',
-          },
-        ];
-  for (let i = 0; i < strongholdStructures.length; i += 1) {
-    const site = strongholdStructures[i]!;
-    createBuildingEntity({ ...site, triggersAlarm: false });
-  }
-
-  const defenders =
-    type === 'AAA'
-      ? [
-          { tx: tx - 1.2, ty: ty + 0.2 },
-          { tx: tx + 1, ty: ty - 0.1 },
-        ]
-      : [
-          { tx: tx - 1.25, ty: ty + 0.2 },
-          { tx: tx + 1.2, ty: ty + 0.3 },
-          { tx: tx + 0.1, ty: ty - 1.2 },
-        ];
-  for (let i = 0; i < defenders.length; i += 1) {
-    spawnAlienUnit(defenders[i]!);
-  }
-}
-
-function clearPickups(): void {
-  for (let i = pickupEntities.length - 1; i >= 0; i -= 1) {
-    const entity = pickupEntities[i]!;
-    destroyEntity(entity);
-  }
-  pickupEntities.length = 0;
-  survivorEntities.length = 0;
-}
-
-function spawnPickupEntity(site: PickupSite): Entity {
-  const entity = entities.create();
-  transforms.set(entity, { tx: site.tx, ty: site.ty, rot: 0 });
-  pickups.set(entity, {
-    kind: site.kind,
-    radius: site.radius ?? 0.9,
-    duration: site.duration ?? 1.3,
-    fuelAmount: site.kind === 'fuel' ? (site.fuelAmount ?? 50) : undefined,
-    ammo:
-      site.kind === 'ammo'
-        ? {
-            missiles: site.ammo?.missiles ?? 80,
-            rockets: site.ammo?.rockets ?? 3,
-            hellfires: site.ammo?.hellfires ?? 0,
-          }
-        : undefined,
-    armorAmount: site.kind === 'armor' ? (site.armorAmount ?? 35) : undefined,
-    collectingBy: null,
-    progress: 0,
-  });
-  pickupEntities.push(entity);
-  return entity;
-}
-
-function spawnPickups(): void {
-  clearPickups();
-  for (let i = 0; i < pickupSites.length; i += 1) {
-    const site = pickupSites[i]!;
-    spawnPickupEntity(site);
-  }
-}
-
-function spawnSurvivors(): void {
-  if (rescueState.survivorsSpawned) return;
-  rescueState.survivorsSpawned = true;
-  for (let i = 0; i < survivorSites.length; i += 1) {
-    const site = survivorSites[i]!;
-    const entity = entities.create();
-    transforms.set(entity, { tx: site.tx, ty: site.ty, rot: 0 });
-    pickups.set(entity, {
-      kind: 'survivor',
-      radius: site.radius ?? 0.9,
-      duration: site.duration ?? 1.6,
-      fuelAmount: undefined,
-      ammo: undefined,
-      survivorCount: site.count,
-      collectingBy: null,
-      progress: 0,
-    });
-    pickupEntities.push(entity);
-    survivorEntities.push(entity);
-  }
-}
-
-function spawnPatrolEnemy(point: { tx: number; ty: number }, wave: number, axis: 'x' | 'y'): void {
-  const entity = entities.create();
-  transforms.set(entity, { tx: point.tx, ty: point.ty, rot: 0 });
-  physics.set(entity, {
-    vx: 0,
-    vy: 0,
-    ax: 0,
-    ay: 0,
-    drag: 0.9,
-    maxSpeed: 2.2 + wave * 0.1,
-    turnRate: Math.PI,
-  });
-  healths.set(entity, { current: 22 + wave * 3, max: 22 + wave * 3 });
-  colliders.set(entity, { radius: 0.4, team: 'enemy' });
-  patrols.set(entity, {
-    axis,
-    originX: point.tx,
-    originY: point.ty,
-    range: 2.5 + Math.min(4, wave * 0.6),
-    speed: 1.8 + wave * 0.2,
-    direction: rng.float01() > 0.5 ? 1 : -1,
-    fireRange: 6.5,
-    fireInterval: Math.max(0.9, 1.4 - wave * 0.1),
-    cooldown: 0,
-  });
-  registerEnemy(entity, { kind: 'patrol', score: 125 + wave * 15, wave });
-}
-
-function spawnChaserEnemy(point: { tx: number; ty: number }, wave: number): void {
-  const entity = entities.create();
-  transforms.set(entity, { tx: point.tx, ty: point.ty, rot: 0 });
-  physics.set(entity, {
-    vx: 0,
-    vy: 0,
-    ax: 0,
-    ay: 0,
-    drag: 0.7,
-    maxSpeed: 3.2 + wave * 0.25,
-    turnRate: Math.PI * 1.4,
-  });
-  healths.set(entity, { current: 26 + wave * 4, max: 26 + wave * 4 });
-  colliders.set(entity, { radius: 0.35, team: 'enemy' });
-  chasers.set(entity, {
-    speed: 2.6 + wave * 0.25,
-    acceleration: 3.2,
-    fireRange: 6,
-    fireInterval: Math.max(0.8, 1.3 - wave * 0.1),
-    cooldown: 0,
-    spread: 0.18,
-  });
-  registerEnemy(entity, { kind: 'chaser', score: 220 + wave * 20, wave });
-}
-
-function spawnAlienUnit(point: { tx: number; ty: number }): void {
-  const entity = entities.create();
-  transforms.set(entity, { tx: point.tx, ty: point.ty, rot: 0 });
-  physics.set(entity, {
-    vx: 0,
-    vy: 0,
-    ax: 0,
-    ay: 0,
-    drag: 0.7,
-    maxSpeed: 3.4,
-    turnRate: Math.PI * 1.5,
-  });
-  healths.set(entity, { current: 36, max: 36 });
-  colliders.set(entity, { radius: 0.35, team: 'enemy' });
-  chasers.set(entity, {
-    speed: 3.1,
-    acceleration: 3.6,
-    fireRange: 6.6,
-    fireInterval: 1,
-    cooldown: 0,
-    spread: 0.22,
-    guard: {
-      homeX: point.tx,
-      homeY: point.ty,
-      holdRadius: 0.45,
-      aggroRange: 5.6,
-      leashRange: 9.5,
-      alerted: false,
-    },
-  });
-  registerEnemy(entity, { kind: 'chaser', score: 260 });
-  alienEntities.add(entity);
-}
-
-function triggerAlienCounterattack(): void {
-  if (aliensTriggered) return;
-  aliensTriggered = true;
-  aliensDefeated = false;
-  for (let i = 0; i < alienSpawnPoints.length; i += 1) {
-    spawnAlienUnit(alienSpawnPoints[i]!);
-  }
-}
-
-function checkBuildingsForAlienTrigger(): void {
-  if (aliensTriggered) return;
-  for (let i = 0; i < buildingEntities.length; i += 1) {
-    const entity = buildingEntities[i]!;
-    const meta = buildingMeta.get(entity);
-    if (!meta || !meta.triggersAlarm) continue;
-    const h = healths.get(entity);
-    if (h && h.current < h.max) {
-      triggerAlienCounterattack();
-      break;
-    }
-  }
-}
-
-function resetPlayer(): void {
-  const t = transforms.get(player);
-  const ph = physics.get(player);
-  const fuel = fuels.get(player);
-  const ammo = ammos.get(player);
-  const health = healths.get(player);
-  if (t && ph && fuel && ammo && health) {
-    t.tx = mission.state.def.startPos.tx;
-    t.ty = mission.state.def.startPos.ty;
-    t.rot = 0;
-    ph.vx = 0;
-    ph.vy = 0;
-    ph.ax = 0;
-    ph.ay = 0;
-    fuel.current = fuel.max;
-    ammo.missiles = ammo.missilesMax;
-    ammo.rockets = ammo.rocketsMax;
-    ammo.hellfires = ammo.hellfiresMax;
-    health.current = health.max;
-    colliders.set(player, { radius: 0.4, team: 'player' });
-  }
-  playerState.respawnTimer = 0;
-  playerState.invulnerable = false;
-  engine.start();
-  engine.setIntensity(0);
-}
-
-function resetGame(targetMissionIndex?: number): void {
-  const clampedTarget = Math.min(
-    targetMissionIndex ?? currentMissionIndex,
-    highestUnlockedMissionIndex,
-  );
-  setMission(clampedTarget);
-  clearEnemies();
-  projectilePool.clear();
-  damage.reset();
-  explosions.length = 0;
-  stats.score = 0;
-  waveState.index = 0;
-  waveState.countdown = initialWaveCountdown;
-  waveState.active = false;
-  waveState.timeInWave = 0;
-  rescueState.carrying = 0;
-  rescueState.rescued = 0;
-  rescueState.survivorsSpawned = false;
-  rescueRunners.length = 0;
-  aliensTriggered = false;
-  aliensDefeated = false;
-  campusLeveled = false;
-  if (scenarioOnReset) scenarioOnReset();
-  spawnBuildings();
-  spawnMissionEnemies();
-  spawnPickups();
-  fog.reset();
-  playerState.lives = 3;
-  resetPlayer();
-  ui.state = 'briefing';
-  setAudioVolumes();
-}
-
-function handlePlayerDeath(): void {
-  if (playerState.invulnerable) return;
-  const t = transforms.get(player);
-  if (t) spawnExplosion(t.tx, t.ty);
-  playExplosion(bus);
-  colliders.remove(player);
-  const ph = physics.get(player);
-  if (ph) {
-    ph.vx = 0;
-    ph.vy = 0;
-    ph.ax = 0;
-    ph.ay = 0;
-  }
-  playerState.lives -= 1;
-  playerState.invulnerable = true;
-  playerState.respawnTimer = 2.5;
-  if (playerState.lives <= 0) {
-    ui.state = 'game-over';
-    waveState.active = false;
-    engine.stop();
-  }
-}
-
-function tryRespawn(dt: number): void {
-  if (!playerState.invulnerable || ui.state === 'game-over') return;
-  playerState.respawnTimer -= dt;
-  if (playerState.respawnTimer <= 0 && playerState.lives > 0) {
-    resetPlayer();
-  }
-}
-
-function handleDeaths(): void {
-  const deaths = damage.consumeDeaths();
-  for (let i = 0; i < deaths.length; i += 1) {
-    const entity = deaths[i]!;
-    if (entity === player) {
-      handlePlayerDeath();
-      continue;
-    }
-    const meta = enemyMeta.get(entity);
-    if (meta) {
-      const t = transforms.get(entity);
-      if (t) spawnExplosion(t.tx, t.ty);
-      playExplosion(bus);
-      stats.score += meta.score;
-      destroyEntity(entity);
-      continue;
-    }
-    const building = buildings.get(entity);
-    if (building) {
-      const t = transforms.get(entity);
-      if (t) spawnExplosion(t.tx, t.ty);
-      playExplosion(bus);
-      const meta = buildingMeta.get(entity);
-      if (meta) {
-        if (meta.score) stats.score += meta.score;
-        if (t && meta.drop) {
-          spawnPickupEntity({
-            tx: t.tx,
-            ty: t.ty,
-            kind: meta.drop.kind,
-            radius: 0.95,
-            duration: 1.4,
-            armorAmount: meta.drop.amount,
-          });
-        }
-      }
-      destroyEntity(entity);
-      continue;
-    }
-    destroyEntity(entity);
-  }
-}
-
-function updateWave(dt: number): void {
-  if (ui.state !== 'in-game') return;
-  if (waveState.active) {
-    waveState.timeInWave += dt;
-    if (waveState.enemies.size === 0) {
-      waveState.active = false;
-      const delay = computeWaveCooldown
-        ? computeWaveCooldown(waveState.index)
-        : Number.POSITIVE_INFINITY;
-      waveState.countdown = delay;
-      if (boatScenario && waveState.index >= boatScenario.waves.length && !boatObjectiveFailed) {
-        boatObjectiveComplete = true;
-      }
-    }
-  } else if (spawnWaveHandler) {
-    if (!Number.isFinite(waveState.countdown)) return;
-    waveState.countdown -= dt;
-    if (waveState.countdown <= 0) {
-      waveState.index += 1;
-      const spawned = spawnWaveHandler(waveState.index);
-      if (spawned) {
-        waveState.active = true;
-        waveState.timeInWave = 0;
-      } else {
-        waveState.countdown = Number.POSITIVE_INFINITY;
-      }
-    }
-  }
-}
-
-setMission(currentMissionIndex);
 const loop = new GameLoop({
   update: (dt) => {
     lastStepDt = dt;
-    const snap = input.readSnapshot();
+    const snapshot = input.readSnapshot();
+    const playing = uiController.update(dt, snapshot);
+    if (!playing) return;
 
-    const pauseDown = isDown(snap, bindings, 'pause');
-    if (pauseDown && !pauseLatch) {
-      if (ui.state === 'in-game') ui.state = 'paused';
-      else if (ui.state === 'paused') ui.state = 'in-game';
-      else if (ui.state === 'title') ui.state = 'in-game';
-    }
-    pauseLatch = pauseDown;
-
-    const muteDown = snap.keys['m'] || snap.keys['M'];
-    if (muteDown && !muteLatch) {
-      audioMuted = !audioMuted;
-      setAudioVolumes();
-    }
-    muteLatch = muteDown;
-
-    if (ui.state === 'title') {
-      const action = titleMenu.update(snap);
-      if (action === 'start') {
-        resetGame();
-      } else if (action === 'settings') ui.state = 'settings';
-      else if (action === 'achievements') ui.state = 'achievements';
-      else if (action === 'about') ui.state = 'about';
-      if (action) saveJson('choppa:ui', ui);
-      return;
-    }
-
-    if (ui.state === 'settings') {
-      if (snap.keys['Escape']) ui.state = 'title';
-      return;
-    }
-
-    if (ui.state === 'achievements') {
-      if (snap.keys['Escape']) ui.state = 'title';
-      return;
-    }
-
-    if (ui.state === 'about') {
-      if (snap.keys['Escape']) ui.state = 'title';
-      return;
-    }
-
-    if (ui.state === 'briefing') {
-      if (snap.keys['Enter'] || snap.keys[' '] || snap.keys['Space']) ui.state = 'in-game';
-      return;
-    }
-
-    if (ui.state === 'paused') {
-      if (snap.keys['Escape']) ui.state = 'in-game';
-      return;
-    }
-
-    if (ui.state === 'game-over') {
-      if (snap.keys['Enter'] || snap.keys[' '] || snap.keys['r'] || snap.keys['R']) {
-        resetGame();
-      }
-      if (snap.keys['Escape']) ui.state = 'title';
-      return;
-    }
-
-    if (ui.state === 'win') {
-      if (snap.keys['Enter'] || snap.keys[' ']) resetGame(nextMissionIndex);
-      if (snap.keys['Escape']) ui.state = 'title';
-      return;
-    }
-
-    tryRespawn(dt);
-
-    const playerTransform = transforms.get(player)!;
-    const ph = physics.get(player)!;
-    const playerFuel = fuels.get(player)!;
-    const playerAmmo = ammos.get(player)!;
-    const playerHealth = healths.get(player)!;
-    let dx = 0;
-    let dy = 0;
-    if (!playerState.invulnerable) {
-      if (isDown(snap, bindings, 'moveUp')) dy -= 1;
-      if (isDown(snap, bindings, 'moveDown')) dy += 1;
-      if (isDown(snap, bindings, 'moveLeft')) dx -= 1;
-      if (isDown(snap, bindings, 'moveRight')) dx += 1;
-      if (isDown(snap, bindings, 'strafeLeft')) dx -= 1;
-      if (isDown(snap, bindings, 'strafeRight')) dx += 1;
-    }
-    if (dx !== 0 || dy !== 0) {
-      const len = Math.hypot(dx, dy) || 1;
-      dx /= len;
-      dy /= len;
-    }
-    const accel = 12;
-    ph.ax = dx * accel;
-    ph.ay = dy * accel;
-
-    const speed = Math.min(1, Math.hypot(ph.vx, ph.vy) / (ph.maxSpeed || 1));
-    engine.start();
-    engine.setIntensity(speed);
-
-    const { width: viewWidth, height: viewHeight } = getCanvasViewMetrics(context);
-    let aimTile = screenToApproxTile(
-      snap.mouseX,
-      snap.mouseY,
-      viewWidth,
-      viewHeight,
-      camera.x,
-      camera.y,
-      isoParams,
-    );
-    const aimDx = aimTile.x - playerTransform.tx;
-    const aimDy = aimTile.y - playerTransform.ty;
-    if (!Number.isFinite(aimDx) || !Number.isFinite(aimDy) || Math.hypot(aimDx, aimDy) < 0.3) {
-      aimTile = {
-        x: playerTransform.tx + Math.cos(playerTransform.rot),
-        y: playerTransform.ty + Math.sin(playerTransform.rot),
-      };
-    }
-    weaponFire.setInput(snap, aimTile.x, aimTile.y);
-
-    scheduler.update(dt);
-
-    const completedPickups: {
-      entity: Entity;
-      kind: Pickup['kind'];
-      fuelAmount?: number;
-      ammo?: { missiles?: number; rockets?: number; hellfires?: number };
-      survivorCount?: number;
-      armorAmount?: number;
-    }[] = [];
-    pickups.forEach((entity, pickup) => {
-      const pickupTransform = transforms.get(entity);
-      if (!pickupTransform) {
-        completePickupCraneSound(entity);
-        completedPickups.push({
-          entity,
-          kind: pickup.kind,
-          fuelAmount: pickup.fuelAmount,
-          ammo: pickup.ammo,
-          armorAmount: pickup.armorAmount,
-        });
-        return;
-      }
-
-      if (pickup.collectingBy === player) {
-        const dx = pickupTransform.tx - playerTransform.tx;
-        const dy = pickupTransform.ty - playerTransform.ty;
-        const dist = Math.hypot(dx, dy);
-        if (dist > pickup.radius + 0.4 || playerState.invulnerable) {
-          pickup.collectingBy = null;
-          pickup.progress = 0;
-          cancelPickupCraneSound(entity);
-          return;
-        }
-        pickup.progress = Math.min(1, pickup.progress + dt / pickup.duration);
-        if (pickup.progress >= 1) {
-          completePickupCraneSound(entity);
-          completedPickups.push({
-            entity,
-            kind: pickup.kind,
-            fuelAmount: pickup.fuelAmount,
-            ammo: pickup.ammo ? { ...pickup.ammo } : undefined,
-            survivorCount: pickup.survivorCount,
-            armorAmount: pickup.armorAmount,
-          });
-        }
-        return;
-      }
-
-      if (pickup.collectingBy && !transforms.has(pickup.collectingBy)) {
-        pickup.collectingBy = null;
-        pickup.progress = 0;
-        cancelPickupCraneSound(entity);
-        return;
-      }
-
-      if (pickup.collectingBy === null) {
-        const dx = pickupTransform.tx - playerTransform.tx;
-        const dy = pickupTransform.ty - playerTransform.ty;
-        const dist = Math.hypot(dx, dy);
-        if (dist <= pickup.radius && !playerState.invulnerable) {
-          if (pickup.kind === 'fuel') {
-            const needsFuel = playerFuel.current < playerFuel.max - 0.5;
-            if (needsFuel) {
-              pickup.collectingBy = player;
-              pickup.progress = 0;
-              beginPickupCraneSound(entity, pickup);
-            }
-          } else if (pickup.kind === 'ammo') {
-            const needsAmmo =
-              playerAmmo.missiles < playerAmmo.missilesMax ||
-              playerAmmo.rockets < playerAmmo.rocketsMax ||
-              playerAmmo.hellfires < playerAmmo.hellfiresMax;
-            if (needsAmmo) {
-              pickup.collectingBy = player;
-              pickup.progress = 0;
-              beginPickupCraneSound(entity, pickup);
-            }
-          } else if (pickup.kind === 'survivor') {
-            const survivors = pickup.survivorCount ?? 1;
-            const remainingCapacity = SURVIVOR_CAPACITY - rescueState.carrying;
-            if (remainingCapacity >= survivors) {
-              pickup.collectingBy = player;
-              pickup.progress = 0;
-              beginPickupCraneSound(entity, pickup);
-            }
-          } else if (pickup.kind === 'armor') {
-            const needsArmor = playerHealth.current < playerHealth.max - 0.5;
-            if (needsArmor) {
-              pickup.collectingBy = player;
-              pickup.progress = 0;
-              beginPickupCraneSound(entity, pickup);
-            }
-          }
-        }
-      }
-    });
-
-    for (let i = 0; i < completedPickups.length; i += 1) {
-      const item = completedPickups[i]!;
-      if (item.kind === 'fuel') {
-        const amount = item.fuelAmount ?? 50;
-        playerFuel.current = Math.min(playerFuel.max, playerFuel.current + amount);
-      } else if (item.kind === 'ammo' && item.ammo) {
-        playerAmmo.rockets = Math.min(
-          playerAmmo.rocketsMax,
-          playerAmmo.rockets + (item.ammo.rockets ?? 0),
-        );
-        playerAmmo.missiles = Math.min(
-          playerAmmo.missilesMax,
-          playerAmmo.missiles + (item.ammo.missiles ?? 0),
-        );
-        playerAmmo.hellfires = Math.min(
-          playerAmmo.hellfiresMax,
-          playerAmmo.hellfires + (item.ammo.hellfires ?? 0),
-        );
-      } else if (item.kind === 'armor') {
-        const amount = item.armorAmount ?? 35;
-        playerHealth.current = Math.min(playerHealth.max, playerHealth.current + amount);
-      } else if (item.kind === 'survivor') {
-        const count = item.survivorCount ?? 1;
-        rescueState.carrying = Math.min(SURVIVOR_CAPACITY, rescueState.carrying + count);
-      }
-      destroyEntity(item.entity);
-    }
-
-    if (rescueState.carrying > 0 && !playerState.invulnerable) {
-      const dxPad = playerTransform.tx - pad.tx;
-      const dyPad = playerTransform.ty - pad.ty;
-      const distPad = Math.hypot(dxPad, dyPad);
-      if (distPad <= pad.radius + 0.2) {
-        const dropped = rescueState.carrying;
-        if (dropped > 0) spawnRescueRunnerAnimation(dropped);
-        rescueState.rescued = Math.min(rescueState.total, rescueState.rescued + dropped);
-        rescueState.carrying = 0;
-      }
-    }
-
-    updateRescueRunnerAnimations(dt);
-
-    const margin = 1.2;
-    const maxX = runtimeMap.width - 1 - margin;
-    const maxY = runtimeMap.height - 1 - margin;
-    playerTransform.tx = Math.max(margin, Math.min(maxX, playerTransform.tx));
-    playerTransform.ty = Math.max(margin, Math.min(maxY, playerTransform.ty));
-
-    for (let i = 0; i < fireEvents.length; i += 1) {
-      const ev = fireEvents[i]!;
-      if (ev.kind === 'missile') {
-        playMissile(bus);
-        const dirLen = Math.hypot(ev.dx, ev.dy) || 1;
-        const dirX = ev.dx / dirLen;
-        const dirY = ev.dy / dirLen;
-        const speedM = ev.speed ?? 22;
-        const launchOffset = ev.launchOffset ?? 0.48;
-        const spawnX = ev.sx + dirX * launchOffset;
-        const spawnY = ev.sy + dirY * launchOffset;
-        projectilePool.spawn({
-          kind: 'missile',
-          faction: ev.faction,
-          x: spawnX,
-          y: spawnY,
-          vx: dirX * speedM,
-          vy: dirY * speedM,
-          ttl: ev.ttl ?? 0.6,
-          radius: ev.radius ?? 0.08,
-          damage: { amount: ev.damage ?? 10, radius: ev.damageRadius ?? 0.12 },
-        });
-      } else if (ev.kind === 'rocket') {
-        playRocket(bus);
-        projectilePool.spawn({
-          kind: 'rocket',
-          faction: ev.faction,
-          x: ev.x,
-          y: ev.y,
-          vx: ev.vx,
-          vy: ev.vy,
-          ttl: ev.ttl ?? 5.2,
-          radius: ev.radius ?? 0.22,
-          damage: { amount: ev.damage ?? 16, radius: ev.damageRadius ?? 0.9 },
-        });
-      } else if (ev.kind === 'hellfire') {
-        playHellfire(bus);
-        const velLen = Math.hypot(ev.vx, ev.vy) || 1;
-        const dirX = ev.vx / velLen;
-        const dirY = ev.vy / velLen;
-        const launchOffset = ev.launchOffset ?? 0.92;
-        const speedH = ev.speed ?? velLen;
-        const spawnX = ev.x + dirX * launchOffset;
-        const spawnY = ev.y + dirY * launchOffset;
-        projectilePool.spawn({
-          kind: 'hellfire',
-          faction: ev.faction,
-          x: spawnX,
-          y: spawnY,
-          vx: dirX * speedH,
-          vy: dirY * speedH,
-          ttl: ev.ttl ?? 3.2,
-          radius: ev.radius ?? 0.3,
-          seek: { targetX: ev.targetX, targetY: ev.targetY, turnRate: Math.PI * 0.8 },
-          damage: { amount: ev.damage ?? 36, radius: ev.damageRadius ?? 1.9 },
-        });
-      }
-    }
-    fireEvents.length = 0;
-
-    projectilePool.update(dt, colliders, colliders, transforms, (hit) => {
-      damage.queue(hit);
-      const boomRadius = Math.max(0.2, hit.radius * 1.45);
-      const boomDuration = 0.32 + hit.radius * 0.38;
-      spawnExplosion(hit.x, hit.y, boomRadius, boomDuration);
-      playExplosion(bus, hit.radius);
-      if (ui.settings.screenShake) shake.trigger(8, 0.25);
-    });
-
-    damage.update();
-    checkBuildingsForAlienTrigger();
-    handleDeaths();
-    if (!campusLeveled) {
-      let campusRemaining = 0;
-      buildingMeta.forEach((meta) => {
-        if (meta.category === 'campus') campusRemaining += 1;
-      });
-      if (campusRemaining === 0) campusLeveled = true;
-    }
-    if (aliensTriggered && !aliensDefeated && alienEntities.size === 0) aliensDefeated = true;
-    if (!rescueState.survivorsSpawned && campusLeveled && aliensDefeated) spawnSurvivors();
-
-    mission.update();
-    if (mission.state.complete && ui.state === 'in-game') {
-      ui.state = 'win';
-      const candidate = Math.min(currentMissionIndex + 1, missionDefs.length - 1);
-      if (candidate > highestUnlockedMissionIndex) {
-        highestUnlockedMissionIndex = candidate;
-      }
-      nextMissionIndex = Math.min(candidate, highestUnlockedMissionIndex);
-      missionProgress.unlocked =
-        missionDefs[highestUnlockedMissionIndex]?.id ?? missionProgress.unlocked;
-      missionProgress.lastWin = Date.now();
-      persistMissionProgress();
-    }
-
-    updateWave(dt);
-    updateExplosions(dt);
+    playerController.update(dt, snapshot, isoParams, runtimeMap);
+    pickupProcessor.update(dt, isoParams, pad, safeHouse);
+    combatProcessor.update(dt);
 
     accumulator += dt;
     frames += 1;
@@ -1864,376 +357,23 @@ const loop = new GameLoop({
     }
   },
   render: () => {
-    resizeCanvasToDisplaySize();
-    const displayWidth = canvas.width;
-    const displayHeight = canvas.height;
-    fog.resize(displayWidth, displayHeight);
-    const { width: viewWidth, height: viewHeight } = getCanvasViewMetrics(context);
-    sky.render(context, camera.x, camera.y);
-
-    if (ui.state === 'title') {
-      titleMenu.render(context, 'Choppa', 'Isometric helicopter action prototype');
-      return;
-    }
-    if (ui.state === 'settings') {
-      renderSettings(context, ui);
-      return;
-    }
-    if (ui.state === 'achievements') {
-      renderAchievements(context);
-      return;
-    }
-    if (ui.state === 'about') {
-      renderAbout(context);
-      return;
-    }
-
-    const playerT = transforms.get(player)!;
-    const bounds = isoMapBounds(runtimeMap.width, runtimeMap.height, isoParams);
-    camera.bounds = bounds;
-    const targetIso = tileToIso(playerT.tx, playerT.ty, isoParams);
-    camera.follow(targetIso.x, targetIso.y, viewWidth, viewHeight);
-
-    const originX = Math.floor(viewWidth / 2 - camera.x);
-    const originY = Math.floor(viewHeight / 2 - camera.y);
-    const shakeOffset = shake.offset(1 / 60);
-    const originWithShakeX = originX + shakeOffset.x;
-    const originWithShakeY = originY + shakeOffset.y;
-    const cameraIsoX = camera.x - shakeOffset.x;
-    const cameraIsoY = camera.y - shakeOffset.y;
-    renderer.draw(context, runtimeMap, isoParams, originWithShakeX, originWithShakeY);
-
-    buildings.forEach((entity, building) => {
-      const t = transforms.get(entity);
-      const h = healths.get(entity);
-      if (!t || !h) return;
-      drawBuilding(context, isoParams, originWithShakeX, originWithShakeY, {
-        tx: t.tx,
-        ty: t.ty,
-        width: building.width,
-        depth: building.depth,
-        height: building.height,
-        bodyColor: building.bodyColor,
-        roofColor: building.roofColor,
-        ruinColor: building.ruinColor,
-        damage01: 1 - h.current / h.max,
-      });
-    });
-
-    drawSafeHouse(context, isoParams, originWithShakeX, originWithShakeY, safeHouse);
-
-    const playerCollectorIso = { x: targetIso.x, y: targetIso.y };
-    pickups.forEach((entity, pickup) => {
-      const t = transforms.get(entity);
-      if (!t) return;
-      let collectorIso: { x: number; y: number } | null = null;
-      if (pickup.collectingBy === player) {
-        collectorIso = playerCollectorIso;
-      } else if (pickup.collectingBy) {
-        const collectorTransform = transforms.get(pickup.collectingBy);
-        if (collectorTransform) {
-          collectorIso = tileToIso(collectorTransform.tx, collectorTransform.ty, isoParams);
-        }
-      }
-      drawPickupCrate(context, isoParams, originWithShakeX, originWithShakeY, {
-        tx: t.tx,
-        ty: t.ty,
-        kind: pickup.kind,
-        collecting: pickup.collectingBy !== null,
-        progress: pickup.progress,
-        collectorIso,
-      });
-    });
-    aaas.forEach((entity, _a) => {
-      const t = transforms.get(entity);
-      if (t) drawAAATurret(context, isoParams, originWithShakeX, originWithShakeY, t.tx, t.ty);
-    });
-    sams.forEach((entity, _s) => {
-      const t = transforms.get(entity);
-      if (t) drawSAM(context, isoParams, originWithShakeX, originWithShakeY, t.tx, t.ty);
-    });
-    patrols.forEach((entity, _p) => {
-      const t = transforms.get(entity);
-      if (t) drawPatrolDrone(context, isoParams, originWithShakeX, originWithShakeY, t.tx, t.ty);
-    });
-    chasers.forEach((entity, _c) => {
-      const t = transforms.get(entity);
-      if (!t) return;
-      if (alienEntities.has(entity)) {
-        drawAlienMonstrosity(context, isoParams, originWithShakeX, originWithShakeY, t.tx, t.ty);
-      } else {
-        drawChaserDrone(context, isoParams, originWithShakeX, originWithShakeY, t.tx, t.ty);
-      }
-    });
-
-    speedboats.forEach((entity, _boat) => {
-      const t = transforms.get(entity);
-      if (!t) return;
-      drawSpeedboat(context, isoParams, originWithShakeX, originWithShakeY, t.tx, t.ty);
-    });
-
-    projectilePool.draw(
-      context,
-      originWithShakeX,
-      originWithShakeY,
-      isoParams.tileWidth,
-      isoParams.tileHeight,
-    );
-
-    for (let i = 0; i < explosions.length; i += 1) {
-      const e = explosions[i]!;
-      const iso = tileToIso(e.tx, e.ty, isoParams);
-      const drawX = originX + iso.x + shakeOffset.x;
-      const drawY = originY + iso.y + shakeOffset.y - 10;
-      const progress = Math.min(1, e.age / e.duration);
-      const alpha = 1 - progress;
-      const scale = Math.max(isoParams.tileWidth, isoParams.tileHeight) * 0.45;
-      const outerRadius = e.radius * scale * (0.9 + (1 - progress) * 0.35);
-      const coreRadius = outerRadius * 0.45;
-
-      // Outer glow
-      context.save();
-      context.globalAlpha = Math.max(0, alpha * 0.9);
-      context.globalCompositeOperation = 'lighter';
-      const gradient = context.createRadialGradient(drawX, drawY, 0, drawX, drawY, outerRadius);
-      gradient.addColorStop(0, 'rgba(255,255,255,0.95)');
-      gradient.addColorStop(0.35, 'rgba(255,214,102,0.85)');
-      gradient.addColorStop(0.75, 'rgba(255,111,89,0.55)');
-      gradient.addColorStop(1, 'rgba(255,71,71,0)');
-      context.fillStyle = gradient;
-      context.beginPath();
-      context.arc(drawX, drawY, outerRadius, 0, Math.PI * 2);
-      context.fill();
-      context.restore();
-
-      // Core flash
-      context.save();
-      context.globalAlpha = Math.max(0, alpha * 0.75);
-      context.fillStyle = '#fff2d5';
-      context.beginPath();
-      context.arc(drawX, drawY, coreRadius, 0, Math.PI * 2);
-      context.fill();
-      context.restore();
-
-      // Shock ring
-      context.save();
-      context.globalAlpha = Math.max(0, alpha * 0.5);
-      context.strokeStyle = '#ffd166';
-      context.lineWidth = 2;
-      const shockRadius = outerRadius * (0.85 + progress * 0.4);
-      context.beginPath();
-      context.arc(drawX, drawY, shockRadius, 0, Math.PI * 2);
-      context.stroke();
-      context.restore();
-    }
-
-    drawPad(context, isoParams, originWithShakeX, originWithShakeY, pad.tx, pad.ty);
-
-    const runnerScale = isoParams.tileHeight / 32;
-    for (let i = 0; i < rescueRunners.length; i += 1) {
-      const runner = rescueRunners[i]!;
-      if (runner.delay > 0) continue;
-      const t = Math.min(1, runner.progress);
-      const isoX = runner.startIso.x + (runner.endIso.x - runner.startIso.x) * t;
-      const isoY = runner.startIso.y + (runner.endIso.y - runner.startIso.y) * t;
-      const drawX = originWithShakeX + isoX;
-      const drawY = originWithShakeY + isoY;
-      const dirX = runner.endIso.x - runner.startIso.x;
-      const dirY = runner.endIso.y - runner.startIso.y;
-      const angle = Math.atan2(dirY, dirX);
-      const phase = runner.elapsed * 11 + runner.bobOffset;
-      const bob = Math.sin(phase) * runnerScale * 1.6;
-      const fade = runner.progress <= 1 ? 1 : Math.max(0, 1 - (runner.progress - 1) / 0.3);
-      drawRescueRunner(context, {
-        x: drawX,
-        y: drawY,
-        angle: Number.isFinite(angle) ? angle : 0,
-        stepPhase: phase,
-        bob,
-        fade,
-        scale: runnerScale,
-      });
-    }
-
-    drawHeli(context, {
-      tx: playerT.tx,
-      ty: playerT.ty,
-      rot: playerT.rot,
-      rotorPhase: sprites.get(player)!.rotor,
-      color: sprites.get(player)!.color,
-      iso: isoParams,
-      originX: originWithShakeX,
-      originY: originWithShakeY,
-    });
-
-    minimapEnemies.length = 0;
-    colliders.forEach((entity, col) => {
-      if (col.team === 'enemy') {
-        const t = transforms.get(entity);
-        if (t) minimapEnemies.push({ tx: t.tx, ty: t.ty });
-      }
-    });
-
-    const revealRadius = Math.max(120, Math.min(viewWidth, viewHeight) * 0.22);
-    fog.reveal(playerT.tx, playerT.ty, revealRadius, isoParams);
-    if (ui.settings.fogOfWar) {
-      fog.render(context, {
-        iso: isoParams,
-        originX: originWithShakeX,
-        originY: originWithShakeY,
-        cameraX: cameraIsoX,
-        cameraY: cameraIsoY,
-        viewWidth,
-        viewHeight,
-      });
-    }
-
-    const fuelComp = fuels.get(player)!;
-    const ammoComp = ammos.get(player)!;
-    const healthComp = healths.get(player)!;
-    const weaponComp = weapons.get(player)!;
-
-    const objectiveLines = mission.state.objectives.map((o) => {
-      const labelFn = objectiveLabelOverrides[o.id];
-      const label = labelFn ? labelFn(o) : o.name;
-      return `${o.complete ? '[x]' : '[ ]'} ${label}`;
-    });
-
-    const nextWaveCountdown =
-      !waveState.active && Number.isFinite(waveState.countdown)
-        ? Math.max(0, waveState.countdown)
-        : null;
-
-    drawHUD(
-      context,
-      {
-        fuel01: fuelComp.current / fuelComp.max,
-        fuelCurrent: fuelComp.current,
-        fuelMax: fuelComp.max,
-        armor01: healthComp.current / healthComp.max,
-        ammo: {
-          missiles: ammoComp.missiles,
-          rockets: ammoComp.rockets,
-          hellfires: ammoComp.hellfires,
-        },
-        ammoMax: {
-          missiles: ammoComp.missilesMax,
-          rockets: ammoComp.rocketsMax,
-          hellfires: ammoComp.hellfiresMax,
-        },
-        activeWeapon: weaponComp.active,
-        lives: Math.max(0, playerState.lives),
-        score: stats.score,
-        wave: waveState.active ? waveState.index : Math.max(1, waveState.index + 1),
-        enemiesRemaining: waveState.enemies.size,
-        nextWaveIn: nextWaveCountdown,
-      },
-      objectiveLines,
-      null,
-      {
-        mapW: runtimeMap.width,
-        mapH: runtimeMap.height,
-        player: { tx: playerT.tx, ty: playerT.ty },
-        enemies: minimapEnemies,
-      },
+    gameSceneRenderer.render({
+      state,
+      ui,
+      titleMenu,
+      mission: missionCoordinator.mission,
+      objectiveLabels: missionCoordinator.objectiveLabelOverrides,
+      missionBriefing,
+      runtimeMap,
       isoParams,
-    );
-
-    if (playerState.invulnerable && ui.state === 'in-game') {
-      context.save();
-      context.fillStyle = 'rgba(0, 0, 0, 0.35)';
-      context.fillRect(0, 0, viewWidth, viewHeight);
-      context.fillStyle = '#ffd166';
-      context.font = 'bold 18px system-ui, sans-serif';
-      context.textAlign = 'center';
-      context.fillText('Respawning...', viewWidth / 2, viewHeight / 2);
-      context.restore();
-    }
-
-    if (ui.state === 'briefing') {
-      context.save();
-      context.fillStyle = 'rgba(4, 10, 18, 0.7)';
-      context.fillRect(0, 0, viewWidth, viewHeight);
-      context.textAlign = 'center';
-      context.fillStyle = '#92ffa6';
-      context.font = 'bold 28px system-ui, sans-serif';
-      context.fillText(missionBriefingInfo.title, viewWidth / 2, viewHeight / 2 - 140);
-      context.fillStyle = '#c8d7e1';
-      context.font = '16px system-ui, sans-serif';
-      const briefingLines = missionBriefingInfo.text.split('\n');
-      for (let i = 0; i < briefingLines.length; i += 1) {
-        context.fillText(briefingLines[i]!, viewWidth / 2, viewHeight / 2 - 100 + i * 22);
-      }
-      context.textAlign = 'left';
-      const goals = missionBriefingInfo.goals.slice(0, 5);
-      const goalX = viewWidth / 2 - 200;
-      let goalY = viewHeight / 2 - 20;
-      context.font = '15px system-ui, sans-serif';
-      for (let i = 0; i < goals.length; i += 1) {
-        context.fillText(`• ${goals[i]!}`, goalX, goalY + i * 22);
-      }
-      context.textAlign = 'center';
-      context.fillStyle = '#92ffa6';
-      context.font = 'bold 16px system-ui, sans-serif';
-      context.fillText('Press Enter to deploy', viewWidth / 2, goalY + goals.length * 22 + 24);
-      context.restore();
-    }
-
-    if (ui.state === 'paused') {
-      context.save();
-      context.fillStyle = 'rgba(0, 0, 0, 0.55)';
-      context.fillRect(0, 0, viewWidth, viewHeight);
-      context.fillStyle = '#92ffa6';
-      context.font = 'bold 28px system-ui, sans-serif';
-      context.textAlign = 'center';
-      context.fillText('Paused', viewWidth / 2, viewHeight / 2);
-      context.fillStyle = '#c8d7e1';
-      context.font = '14px system-ui, sans-serif';
-      context.fillText('Press Esc to resume', viewWidth / 2, viewHeight / 2 + 24);
-      context.restore();
-    }
-
-    if (ui.state === 'game-over') {
-      context.save();
-      context.fillStyle = 'rgba(0, 0, 0, 0.7)';
-      context.fillRect(0, 0, viewWidth, viewHeight);
-      context.fillStyle = '#ef476f';
-      context.font = 'bold 28px system-ui, sans-serif';
-      context.textAlign = 'center';
-      context.fillText('Mission Failed', viewWidth / 2, viewHeight / 2);
-      context.fillStyle = '#c8d7e1';
-      context.font = '14px system-ui, sans-serif';
-      context.fillText(
-        'Press Enter to restart or Esc for title',
-        viewWidth / 2,
-        viewHeight / 2 + 26,
-      );
-      context.restore();
-      return;
-    }
-
-    if (ui.state === 'win') {
-      context.save();
-      context.fillStyle = 'rgba(0,0,0,0.6)';
-      context.fillRect(0, 0, viewWidth, viewHeight);
-      context.fillStyle = '#92ffa6';
-      context.font = 'bold 28px system-ui, sans-serif';
-      context.textAlign = 'center';
-      context.fillText('Mission Complete', viewWidth / 2, viewHeight / 2 - 8);
-      context.fillStyle = '#c8d7e1';
-      context.font = '14px system-ui, sans-serif';
-      context.fillText(
-        'Press Enter to restart or Esc for title',
-        viewWidth / 2,
-        viewHeight / 2 + 16,
-      );
-      context.restore();
-      return;
-    }
-
-    debug.render(context, { fps, dt: lastStepDt, entities: enemyMeta.size + 1 });
+      stores,
+      player,
+      pad,
+      safeHouse,
+      fps,
+      dt: lastStepDt,
+    });
   },
 });
 
 loop.start();
-

--- a/src/render/scene/gameScene.ts
+++ b/src/render/scene/gameScene.ts
@@ -1,0 +1,516 @@
+import type { RuntimeTilemap } from '../../world/tiles/tiled';
+import { isoMapBounds, tileToIso } from '../../render/iso/projection';
+import { getCanvasViewMetrics } from '../../render/canvas/metrics';
+import { drawBuilding } from '../../render/sprites/buildings';
+import { drawSafeHouse, type SafeHouseParams } from '../../render/sprites/safehouse';
+import { drawPickupCrate } from '../../render/sprites/pickups';
+import {
+  drawAAATurret,
+  drawSAM,
+  drawPatrolDrone,
+  drawChaserDrone,
+  drawAlienMonstrosity,
+  drawSpeedboat,
+} from '../../render/sprites/targets';
+import { drawPad, drawHeli } from '../../render/sprites/heli';
+import { drawRescueRunner } from '../../render/sprites/rescuees';
+import { drawHUD } from '../../ui/hud/hud';
+import { renderSettings, renderAchievements, renderAbout } from '../../ui/menus/renderers';
+import type { Menu } from '../../ui/menus/menu';
+import type { UIStore } from '../../ui/menus/scenes';
+import type { MissionTracker } from '../../game/missions/tracker';
+import type { MissionCoordinator, ObjectiveLabelFn } from '../../game/missions/coordinator';
+import type { GameState } from '../../game/app/state';
+import type { BootstrapResult } from '../../game/app/bootstrap';
+import type { Entity } from '../../core/ecs/entities';
+import type { Camera2D } from '../camera/camera';
+import type { IsoTilemapRenderer } from '../draw/tilemap';
+import type { ParallaxSky } from '../draw/parallax';
+import type { FogOfWar } from '../draw/fog';
+import type { CameraShake } from '../camera/shake';
+import type { ProjectilePool } from '../../game/systems/Projectile';
+import type { DebugOverlay } from '../debug/overlay';
+import type { PadConfig } from '../../game/scenarios/layouts';
+
+export interface GameSceneRendererDeps {
+  canvas: HTMLCanvasElement;
+  context: CanvasRenderingContext2D;
+  resizeCanvasToDisplaySize: () => void;
+  renderer: IsoTilemapRenderer;
+  camera: Camera2D;
+  sky: ParallaxSky;
+  fog: FogOfWar;
+  shake: CameraShake;
+  projectilePool: ProjectilePool;
+  debug: DebugOverlay;
+}
+
+export interface GameSceneRenderArgs {
+  state: GameState;
+  ui: UIStore;
+  titleMenu: Menu;
+  mission: MissionTracker;
+  objectiveLabels: Record<string, ObjectiveLabelFn>;
+  missionBriefing: ReturnType<MissionCoordinator['getBriefing']>;
+  runtimeMap: RuntimeTilemap;
+  isoParams: { tileWidth: number; tileHeight: number };
+  stores: BootstrapResult['stores'];
+  player: Entity;
+  pad: PadConfig;
+  safeHouse: SafeHouseParams;
+  fps: number;
+  dt: number;
+}
+
+export interface GameSceneRenderer {
+  render: (args: GameSceneRenderArgs) => void;
+}
+
+export function createGameSceneRenderer(deps: GameSceneRendererDeps): GameSceneRenderer {
+  const renderMenuScenes = (args: GameSceneRenderArgs): boolean => {
+    const { ui, titleMenu } = args;
+    if (ui.state === 'title') {
+      titleMenu.render(deps.context, 'Choppa', 'Isometric helicopter action prototype');
+      return true;
+    }
+    if (ui.state === 'settings') {
+      renderSettings(deps.context, ui);
+      return true;
+    }
+    if (ui.state === 'achievements') {
+      renderAchievements(deps.context);
+      return true;
+    }
+    if (ui.state === 'about') {
+      renderAbout(deps.context);
+      return true;
+    }
+    return false;
+  };
+
+  const renderWorldLayer = (
+    args: GameSceneRenderArgs,
+    originWithShakeX: number,
+    originWithShakeY: number,
+  ): void => {
+    const { runtimeMap, isoParams, stores, safeHouse } = args;
+    deps.renderer.draw(deps.context, runtimeMap, isoParams, originWithShakeX, originWithShakeY);
+
+    stores.buildings.forEach((entity, building) => {
+      const t = stores.transforms.get(entity);
+      const h = stores.healths.get(entity);
+      if (!t || !h) return;
+      drawBuilding(deps.context, isoParams, originWithShakeX, originWithShakeY, {
+        tx: t.tx,
+        ty: t.ty,
+        width: building.width,
+        depth: building.depth,
+        height: building.height,
+        bodyColor: building.bodyColor,
+        roofColor: building.roofColor,
+        ruinColor: building.ruinColor,
+        damage01: 1 - h.current / h.max,
+      });
+    });
+
+    drawSafeHouse(deps.context, isoParams, originWithShakeX, originWithShakeY, safeHouse);
+  };
+
+  const renderEntityLayer = (
+    args: GameSceneRenderArgs,
+    originWithShakeX: number,
+    originWithShakeY: number,
+  ): void => {
+    const { isoParams, stores, player, state, pad } = args;
+    const playerTransform = stores.transforms.get(player);
+    if (!playerTransform) return;
+
+    const playerCollectorIso = tileToIso(playerTransform.tx, playerTransform.ty, isoParams);
+    stores.pickups.forEach((entity, pickup) => {
+      const t = stores.transforms.get(entity);
+      if (!t) return;
+      let collectorIso: { x: number; y: number } | null = null;
+      if (pickup.collectingBy === player) {
+        collectorIso = playerCollectorIso;
+      } else if (pickup.collectingBy) {
+        const collectorTransform = stores.transforms.get(pickup.collectingBy);
+        if (collectorTransform) {
+          collectorIso = tileToIso(collectorTransform.tx, collectorTransform.ty, isoParams);
+        }
+      }
+      drawPickupCrate(deps.context, isoParams, originWithShakeX, originWithShakeY, {
+        tx: t.tx,
+        ty: t.ty,
+        kind: pickup.kind,
+        collecting: pickup.collectingBy !== null,
+        progress: pickup.progress,
+        collectorIso,
+      });
+    });
+
+    stores.aaas.forEach((entity) => {
+      const t = stores.transforms.get(entity);
+      if (t) drawAAATurret(deps.context, isoParams, originWithShakeX, originWithShakeY, t.tx, t.ty);
+    });
+    stores.sams.forEach((entity) => {
+      const t = stores.transforms.get(entity);
+      if (t) drawSAM(deps.context, isoParams, originWithShakeX, originWithShakeY, t.tx, t.ty);
+    });
+    stores.patrols.forEach((entity) => {
+      const t = stores.transforms.get(entity);
+      if (t)
+        drawPatrolDrone(deps.context, isoParams, originWithShakeX, originWithShakeY, t.tx, t.ty);
+    });
+    stores.chasers.forEach((entity) => {
+      const t = stores.transforms.get(entity);
+      if (!t) return;
+      if (state.alienEntities.has(entity)) {
+        drawAlienMonstrosity(
+          deps.context,
+          isoParams,
+          originWithShakeX,
+          originWithShakeY,
+          t.tx,
+          t.ty,
+        );
+      } else {
+        drawChaserDrone(deps.context, isoParams, originWithShakeX, originWithShakeY, t.tx, t.ty);
+      }
+    });
+    stores.speedboats.forEach((entity) => {
+      const t = stores.transforms.get(entity);
+      if (t) drawSpeedboat(deps.context, isoParams, originWithShakeX, originWithShakeY, t.tx, t.ty);
+    });
+
+    deps.projectilePool.draw(
+      deps.context,
+      originWithShakeX,
+      originWithShakeY,
+      isoParams.tileWidth,
+      isoParams.tileHeight,
+    );
+
+    for (let i = 0; i < state.explosions.length; i += 1) {
+      const explosion = state.explosions[i]!;
+      const iso = tileToIso(explosion.tx, explosion.ty, isoParams);
+      const drawX = originWithShakeX + iso.x;
+      const drawY = originWithShakeY + iso.y - 10;
+      const progress = Math.min(1, explosion.age / explosion.duration);
+      const alpha = 1 - progress;
+      const scale = Math.max(isoParams.tileWidth, isoParams.tileHeight) * 0.45;
+      const outerRadius = explosion.radius * scale * (0.9 + (1 - progress) * 0.35);
+      const coreRadius = outerRadius * 0.45;
+
+      deps.context.save();
+      deps.context.globalAlpha = Math.max(0, alpha * 0.9);
+      deps.context.globalCompositeOperation = 'lighter';
+      const gradient = deps.context.createRadialGradient(
+        drawX,
+        drawY,
+        0,
+        drawX,
+        drawY,
+        outerRadius,
+      );
+      gradient.addColorStop(0, 'rgba(255,255,255,0.95)');
+      gradient.addColorStop(0.35, 'rgba(255,214,102,0.85)');
+      gradient.addColorStop(0.75, 'rgba(255,111,89,0.55)');
+      gradient.addColorStop(1, 'rgba(255,71,71,0)');
+      deps.context.fillStyle = gradient;
+      deps.context.beginPath();
+      deps.context.arc(drawX, drawY, outerRadius, 0, Math.PI * 2);
+      deps.context.fill();
+      deps.context.restore();
+
+      deps.context.save();
+      deps.context.globalAlpha = Math.max(0, alpha * 0.75);
+      deps.context.fillStyle = '#fff2d5';
+      deps.context.beginPath();
+      deps.context.arc(drawX, drawY, coreRadius, 0, Math.PI * 2);
+      deps.context.fill();
+      deps.context.restore();
+
+      deps.context.save();
+      deps.context.globalAlpha = Math.max(0, alpha * 0.5);
+      deps.context.strokeStyle = '#ffd166';
+      deps.context.lineWidth = 2;
+      const shockRadius = outerRadius * (0.85 + progress * 0.4);
+      deps.context.beginPath();
+      deps.context.arc(drawX, drawY, shockRadius, 0, Math.PI * 2);
+      deps.context.stroke();
+      deps.context.restore();
+    }
+
+    drawPad(deps.context, isoParams, originWithShakeX, originWithShakeY, pad.tx, pad.ty);
+
+    const runnerScale = isoParams.tileHeight / 32;
+    for (let i = 0; i < state.rescueRunners.length; i += 1) {
+      const runner = state.rescueRunners[i]!;
+      if (runner.delay > 0) continue;
+      const t = Math.min(1, runner.progress);
+      const isoX = runner.startIso.x + (runner.endIso.x - runner.startIso.x) * t;
+      const isoY = runner.startIso.y + (runner.endIso.y - runner.startIso.y) * t;
+      const drawX = originWithShakeX + isoX;
+      const drawY = originWithShakeY + isoY;
+      const dirX = runner.endIso.x - runner.startIso.x;
+      const dirY = runner.endIso.y - runner.startIso.y;
+      const angle = Math.atan2(dirY, dirX);
+      const phase = runner.elapsed * 11 + runner.bobOffset;
+      const bob = Math.sin(phase) * runnerScale * 1.6;
+      const fade = runner.progress <= 1 ? 1 : Math.max(0, 1 - (runner.progress - 1) / 0.3);
+      drawRescueRunner(deps.context, {
+        x: drawX,
+        y: drawY,
+        angle: Number.isFinite(angle) ? angle : 0,
+        stepPhase: phase,
+        bob,
+        fade,
+        scale: runnerScale,
+      });
+    }
+
+    const sprite = stores.sprites.get(player);
+    if (!sprite) return;
+    drawHeli(deps.context, {
+      tx: playerTransform.tx,
+      ty: playerTransform.ty,
+      rot: playerTransform.rot,
+      rotorPhase: sprite.rotor,
+      color: sprite.color,
+      iso: isoParams,
+      originX: originWithShakeX,
+      originY: originWithShakeY,
+    });
+  };
+
+  const renderUiLayer = (
+    args: GameSceneRenderArgs,
+    viewWidth: number,
+    viewHeight: number,
+    originWithShakeX: number,
+    originWithShakeY: number,
+    cameraIsoX: number,
+    cameraIsoY: number,
+  ): void => {
+    const { state, ui, mission, objectiveLabels, isoParams, stores, player, missionBriefing } =
+      args;
+    const playerTransform = stores.transforms.get(player);
+    if (!playerTransform) return;
+
+    state.minimapEnemies.length = 0;
+    stores.colliders.forEach((entity, collider) => {
+      if (collider.team !== 'enemy') return;
+      const t = stores.transforms.get(entity);
+      if (t) state.minimapEnemies.push({ tx: t.tx, ty: t.ty });
+    });
+
+    const revealRadius = Math.max(120, Math.min(viewWidth, viewHeight) * 0.22);
+    deps.fog.reveal(playerTransform.tx, playerTransform.ty, revealRadius, isoParams);
+    if (ui.settings.fogOfWar) {
+      deps.fog.render(deps.context, {
+        iso: isoParams,
+        originX: originWithShakeX,
+        originY: originWithShakeY,
+        cameraX: cameraIsoX,
+        cameraY: cameraIsoY,
+        viewWidth,
+        viewHeight,
+      });
+    }
+
+    const fuelComp = stores.fuels.get(player)!;
+    const ammoComp = stores.ammos.get(player)!;
+    const healthComp = stores.healths.get(player)!;
+    const weaponComp = stores.weapons.get(player)!;
+
+    const objectiveLines = mission.state.objectives.map((objective) => {
+      const labelFn = objectiveLabels[objective.id];
+      const label = labelFn ? labelFn(objective) : objective.name;
+      return `${objective.complete ? '[x]' : '[ ]'} ${label}`;
+    });
+
+    const nextWaveCountdown =
+      !state.wave.active && Number.isFinite(state.wave.countdown)
+        ? Math.max(0, state.wave.countdown)
+        : null;
+
+    drawHUD(
+      deps.context,
+      {
+        fuel01: fuelComp.current / fuelComp.max,
+        fuelCurrent: fuelComp.current,
+        fuelMax: fuelComp.max,
+        armor01: healthComp.current / healthComp.max,
+        ammo: {
+          missiles: ammoComp.missiles,
+          rockets: ammoComp.rockets,
+          hellfires: ammoComp.hellfires,
+        },
+        ammoMax: {
+          missiles: ammoComp.missilesMax,
+          rockets: ammoComp.rocketsMax,
+          hellfires: ammoComp.hellfiresMax,
+        },
+        activeWeapon: weaponComp.active,
+        lives: Math.max(0, state.player.lives),
+        score: state.stats.score,
+        wave: state.wave.active ? state.wave.index : Math.max(1, state.wave.index + 1),
+        enemiesRemaining: state.wave.enemies.size,
+        nextWaveIn: nextWaveCountdown,
+      },
+      objectiveLines,
+      null,
+      {
+        mapW: args.runtimeMap.width,
+        mapH: args.runtimeMap.height,
+        player: { tx: playerTransform.tx, ty: playerTransform.ty },
+        enemies: state.minimapEnemies,
+      },
+      isoParams,
+    );
+
+    if (state.player.invulnerable && ui.state === 'in-game') {
+      deps.context.save();
+      deps.context.fillStyle = 'rgba(0, 0, 0, 0.35)';
+      deps.context.fillRect(0, 0, viewWidth, viewHeight);
+      deps.context.fillStyle = '#ffd166';
+      deps.context.font = 'bold 18px system-ui, sans-serif';
+      deps.context.textAlign = 'center';
+      deps.context.fillText('Respawning...', viewWidth / 2, viewHeight / 2);
+      deps.context.restore();
+    }
+
+    if (ui.state === 'briefing') {
+      deps.context.save();
+      deps.context.fillStyle = 'rgba(4, 10, 18, 0.7)';
+      deps.context.fillRect(0, 0, viewWidth, viewHeight);
+      deps.context.textAlign = 'center';
+      deps.context.fillStyle = '#92ffa6';
+      deps.context.font = 'bold 28px system-ui, sans-serif';
+      deps.context.fillText(missionBriefing.title, viewWidth / 2, viewHeight / 2 - 140);
+      deps.context.fillStyle = '#c8d7e1';
+      deps.context.font = '16px system-ui, sans-serif';
+      const briefingLines = missionBriefing.text.split('\n');
+      for (let i = 0; i < briefingLines.length; i += 1) {
+        deps.context.fillText(briefingLines[i]!, viewWidth / 2, viewHeight / 2 - 100 + i * 22);
+      }
+      deps.context.textAlign = 'left';
+      const goals = missionBriefing.goals.slice(0, 5);
+      const goalX = viewWidth / 2 - 200;
+      let goalY = viewHeight / 2 - 20;
+      deps.context.font = '15px system-ui, sans-serif';
+      for (let i = 0; i < goals.length; i += 1) {
+        deps.context.fillText(`• ${goals[i]!}`, goalX, goalY + i * 22);
+      }
+      deps.context.textAlign = 'center';
+      deps.context.fillStyle = '#92ffa6';
+      deps.context.font = 'bold 16px system-ui, sans-serif';
+      deps.context.fillText('Press Enter to deploy', viewWidth / 2, goalY + goals.length * 22 + 24);
+      deps.context.restore();
+    }
+
+    if (ui.state === 'paused') {
+      deps.context.save();
+      deps.context.fillStyle = 'rgba(0, 0, 0, 0.55)';
+      deps.context.fillRect(0, 0, viewWidth, viewHeight);
+      deps.context.fillStyle = '#92ffa6';
+      deps.context.font = 'bold 28px system-ui, sans-serif';
+      deps.context.textAlign = 'center';
+      deps.context.fillText('Paused', viewWidth / 2, viewHeight / 2);
+      deps.context.fillStyle = '#c8d7e1';
+      deps.context.font = '14px system-ui, sans-serif';
+      deps.context.fillText('Press Esc to resume', viewWidth / 2, viewHeight / 2 + 24);
+      deps.context.restore();
+    }
+
+    if (ui.state === 'game-over') {
+      deps.context.save();
+      deps.context.fillStyle = 'rgba(0, 0, 0, 0.7)';
+      deps.context.fillRect(0, 0, viewWidth, viewHeight);
+      deps.context.fillStyle = '#ef476f';
+      deps.context.font = 'bold 28px system-ui, sans-serif';
+      deps.context.textAlign = 'center';
+      deps.context.fillText('Mission Failed', viewWidth / 2, viewHeight / 2);
+      deps.context.fillStyle = '#c8d7e1';
+      deps.context.font = '14px system-ui, sans-serif';
+      deps.context.fillText(
+        'Press Enter to restart or Esc for title',
+        viewWidth / 2,
+        viewHeight / 2 + 26,
+      );
+      deps.context.restore();
+      return;
+    }
+
+    if (ui.state === 'win') {
+      deps.context.save();
+      deps.context.fillStyle = 'rgba(0,0,0,0.6)';
+      deps.context.fillRect(0, 0, viewWidth, viewHeight);
+      deps.context.fillStyle = '#92ffa6';
+      deps.context.font = 'bold 28px system-ui, sans-serif';
+      deps.context.textAlign = 'center';
+      deps.context.fillText('Mission Complete', viewWidth / 2, viewHeight / 2 - 8);
+      deps.context.fillStyle = '#c8d7e1';
+      deps.context.font = '14px system-ui, sans-serif';
+      deps.context.fillText(
+        'Press Enter to restart or Esc for title',
+        viewWidth / 2,
+        viewHeight / 2 + 16,
+      );
+      deps.context.restore();
+    }
+  };
+
+  return {
+    render: (args: GameSceneRenderArgs) => {
+      deps.resizeCanvasToDisplaySize();
+      const displayWidth = deps.canvas.width;
+      const displayHeight = deps.canvas.height;
+      deps.fog.resize(displayWidth, displayHeight);
+
+      const { width: viewWidth, height: viewHeight } = getCanvasViewMetrics(deps.context);
+      deps.sky.render(deps.context, deps.camera.x, deps.camera.y);
+
+      if (renderMenuScenes(args)) {
+        return;
+      }
+
+      const playerTransform = args.stores.transforms.get(args.player);
+      if (!playerTransform) return;
+
+      deps.camera.bounds = isoMapBounds(
+        args.runtimeMap.width,
+        args.runtimeMap.height,
+        args.isoParams,
+      );
+      const targetIso = tileToIso(playerTransform.tx, playerTransform.ty, args.isoParams);
+      deps.camera.follow(targetIso.x, targetIso.y, viewWidth, viewHeight);
+
+      const originX = Math.floor(viewWidth / 2 - deps.camera.x);
+      const originY = Math.floor(viewHeight / 2 - deps.camera.y);
+      const shakeOffset = deps.shake.offset(1 / 60);
+      const originWithShakeX = originX + shakeOffset.x;
+      const originWithShakeY = originY + shakeOffset.y;
+      const cameraIsoX = deps.camera.x - shakeOffset.x;
+      const cameraIsoY = deps.camera.y - shakeOffset.y;
+
+      renderWorldLayer(args, originWithShakeX, originWithShakeY);
+      renderEntityLayer(args, originWithShakeX, originWithShakeY);
+      renderUiLayer(
+        args,
+        viewWidth,
+        viewHeight,
+        originWithShakeX,
+        originWithShakeY,
+        cameraIsoX,
+        cameraIsoY,
+      );
+
+      deps.debug.render(deps.context, {
+        fps: args.fps,
+        dt: args.dt,
+        entities: args.state.enemyMeta.size + 1,
+      });
+    },
+  };
+}


### PR DESCRIPTION
## Summary
- add bootstrap, state, spawn, and mission coordination modules to own initialization concerns
- move player, UI, pickups, and combat updates into dedicated helpers and centralize render logic in render/scene
- rewrite main.ts as a thin composer that wires new modules together

## Testing
- npm run lint
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d2b819e1a88327ada8ddc6993b7062