### PR TITLE
Play rescue cue when survivors spawn

### DIFF
--- a/src/game/app/update/combat.ts
+++ b/src/game/app/update/combat.ts
@@ -46,6 +46,7 @@ export interface CombatProcessorDeps {
   destroyEntity: (entity: Entity) => void;
   engine: EngineSound;
   spawnAlienUnit: (point: { tx: number; ty: number }) => void;
+  getRescueCueBuffer?: () => AudioBuffer | null;
 }
 
 export interface CombatProcessor {
@@ -76,6 +77,7 @@ export function createCombatProcessor({
   destroyEntity,
   engine,
   spawnAlienUnit,
+  getRescueCueBuffer = () => null,
 }: CombatProcessorDeps): CombatProcessor {
   const spawnExplosion = (tx: number, ty: number, radius = 0.9, duration = 0.6): void => {
     state.explosions.push({ tx, ty, age: 0, duration, radius });
@@ -320,6 +322,8 @@ export function createCombatProcessor({
 
     if (!state.rescue.survivorsSpawned && state.flags.campusLeveled && state.flags.aliensDefeated) {
       spawnSurvivors(scenario.survivorSites);
+      const rescueCue = getRescueCueBuffer();
+      if (rescueCue) bus.playSfx(rescueCue);
       state.rescue.survivorsSpawned = true;
       state.rescue.total = scenario.survivorSites.reduce(
         (sum, site) => sum + Math.max(0, Math.round(site.count)),

--- a/src/game/app/update/ui.ts
+++ b/src/game/app/update/ui.ts
@@ -243,4 +243,3 @@ export function createUIController({
     isAudioMuted: () => audioMuted,
   };
 }
-

--- a/src/main.ts
+++ b/src/main.ts
@@ -49,6 +49,23 @@ const {
   setBoatLandingHandler,
 } = bootstrap;
 
+const audioBaseUrl = (import.meta.env.BASE_URL ?? '/').replace(/\/?$/, '/');
+const rescueCueUrl = `${audioBaseUrl}audio/GTTC.mp3`;
+let rescueCueBuffer: AudioBuffer | null = null;
+
+void (async () => {
+  try {
+    const response = await fetch(rescueCueUrl);
+    if (!response.ok) throw new Error(`HTTP ${response.status}`);
+    const arrayBuffer = await response.arrayBuffer();
+    rescueCueBuffer = await new Promise<AudioBuffer>((resolve, reject) => {
+      audio.bus.context.decodeAudioData(arrayBuffer.slice(0), resolve, reject);
+    });
+  } catch (err) {
+    console.warn('[audio] Failed to load rescue cue', err);
+  }
+})();
+
 void audio.music.play('title');
 
 const player = entities.create();
@@ -302,6 +319,7 @@ const combatProcessor = createCombatProcessor({
   destroyEntity,
   engine: audio.engine,
   spawnAlienUnit,
+  getRescueCueBuffer: () => rescueCueBuffer,
 });
 
 setBoatLandingHandler(combatProcessor.handleBoatLanding);


### PR DESCRIPTION
## Summary
- preload the GTTC rescue cue during bootstrap so it is available in-game
- trigger the cue once when survivors spawn after the campus is cleared and aliens are defeated
- normalize the trailing newline in the UI controller module to satisfy linting

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d2e2f4b82883279a5811ea97819a4d