### PR TITLE
Rotate rescue runners toward safe house

### DIFF
--- a/src/render/sprites/rescuees.ts
+++ b/src/render/sprites/rescuees.ts
@@ -32,7 +32,8 @@ export function drawRescueRunner(
     ctx.restore();
   }
 
-  ctx.rotate(params.angle - Math.PI / 2);
+  // Rotate 90° counter-clockwise so runners face the safe house correctly.
+  ctx.rotate(params.angle - Math.PI);
 
   // Legs
   const legOffset = Math.sin(params.stepPhase) * bodyWidth * 0.55;


### PR DESCRIPTION
## Summary
- rotate the rescue runner sprite 90° counter-clockwise so the survivors face the safe house during their run

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d3237ff3708327b681ffbaa24a3cbf