### PR TITLE
Add controls primer to mission one intro

### DIFF
--- a/src/game/data/missions/sample_mission.json
+++ b/src/game/data/missions/sample_mission.json
@@ -5,6 +5,7 @@
   "introDialog": [
     "Ops: Recon spots survivors pinned between the alien towers.",
     "XO: Take down their guns, hold the quad, and get our people out.",
+    "Ops: Quick refresher—WASD or arrows fly, Q/E strafes, Space fires guns, Shift launches missiles, Ctrl drops hellfires.",
     "Pilot: Copy. Rotors spun and missiles hot."
   ],
   "startPos": { "tx": 47, "ty": 47 },


### PR DESCRIPTION
## Summary
- add a mission-one intro dialog line that reiterates the core controls so players who launch immediately still see them

## Testing
- npm run lint


------
https://chatgpt.com/codex/tasks/task_e_68d32470f5d48327bc181772dd2aadcf