### PR TITLE
Implement achievements system and UI

### DIFF
--- a/src/game/achievements/definitions.ts
+++ b/src/game/achievements/definitions.ts
@@ -1,0 +1,73 @@
+export interface AchievementDef {
+  id: string;
+  title: string;
+  description: string;
+  sortOrder?: number;
+}
+
+export const ACHIEVEMENTS: AchievementDef[] = [
+  {
+    id: 'rookie-strike',
+    title: 'Rookie Strike',
+    description: 'Destroy your first hostile unit.',
+    sortOrder: 10,
+  },
+  {
+    id: 'campus-liberator',
+    title: 'Campus Liberator',
+    description: 'Level the alien command campus in Operation Dawnshield.',
+    sortOrder: 20,
+  },
+  {
+    id: 'counterattack-crushed',
+    title: 'Counterattack Crushed',
+    description: 'Trigger the alien counterattack and wipe every invader from the valley.',
+    sortOrder: 30,
+  },
+  {
+    id: 'evac-ace',
+    title: 'Evacuation Ace',
+    description: 'Rescue every survivor in a single mission.',
+    sortOrder: 40,
+  },
+  {
+    id: 'wavebreaker',
+    title: 'Wavebreaker',
+    description: 'Survive every drone wave during Operation Dawnshield.',
+    sortOrder: 50,
+  },
+  {
+    id: 'dawnshield-complete',
+    title: 'Operation Dawnshield',
+    description: 'Complete the first campaign mission.',
+    sortOrder: 60,
+  },
+  {
+    id: 'stormbreak-guardian',
+    title: 'Stormbreak Guardian',
+    description: 'Hold the breakwater without losing a single convoy ship.',
+    sortOrder: 70,
+  },
+  {
+    id: 'starfall-complete',
+    title: 'Operation Starfall',
+    description: 'Crack the mothership shield and secure the breach.',
+    sortOrder: 80,
+  },
+  {
+    id: 'light-the-fuse',
+    title: 'Light the Fuse',
+    description: 'Arm the nuke inside the hivemind well.',
+    sortOrder: 90,
+  },
+  {
+    id: 'black-sun-complete',
+    title: 'Operation Black Sun',
+    description: 'Detonate the nuke and extract from the alien homeworld.',
+    sortOrder: 100,
+  },
+];
+
+export const achievementMap = new Map<string, AchievementDef>(
+  ACHIEVEMENTS.map((achievement) => [achievement.id, achievement]),
+);

--- a/src/game/achievements/tracker.ts
+++ b/src/game/achievements/tracker.ts
@@ -1,0 +1,160 @@
+import type { UIStore } from '../../ui/menus/scenes';
+import type { GameState } from '../app/state';
+import type { MissionTracker } from '../missions/tracker';
+import { ACHIEVEMENTS, achievementMap } from './definitions';
+
+const ORDER_LOOKUP = new Map<string, number>();
+ACHIEVEMENTS.forEach((achievement, index) => {
+  ORDER_LOOKUP.set(achievement.id, achievement.sortOrder ?? (index + 1) * 10);
+});
+
+const BANNER_FADE_IN = 0.25;
+const BANNER_HOLD = 3.25;
+const BANNER_FADE_OUT = 0.55;
+const BANNER_LIFETIME = BANNER_FADE_IN + BANNER_HOLD + BANNER_FADE_OUT;
+
+interface BannerState {
+  id: string;
+  age: number;
+}
+
+export interface AchievementBannerView {
+  id: string;
+  title: string;
+  description: string;
+  alpha: number;
+  slideOffset: number;
+}
+
+export interface AchievementRenderState {
+  definitions: AchievementDef[];
+  unlocked: ReadonlySet<string>;
+  banners: AchievementBannerView[];
+}
+
+export interface AchievementTrackerDeps {
+  ui: UIStore;
+  saveUI: (ui: UIStore) => void;
+}
+
+export class AchievementTracker {
+  private readonly ui: UIStore;
+
+  private readonly saveUI: (ui: UIStore) => void;
+
+  private readonly unlocked = new Set<string>();
+
+  private readonly banners: BannerState[] = [];
+
+  public constructor({ ui, saveUI }: AchievementTrackerDeps) {
+    this.ui = ui;
+    this.saveUI = saveUI;
+
+    const saved = Array.isArray(ui.achievements?.unlocked) ? ui.achievements.unlocked : [];
+    for (let i = 0; i < saved.length; i += 1) {
+      const id = saved[i];
+      if (id && typeof id === 'string') {
+        this.unlocked.add(id);
+      }
+    }
+    this.syncStore();
+  }
+
+  public update(dt: number, state: GameState, mission: MissionTracker): void {
+    this.updateBanners(dt);
+
+    if (state.stats.score > 0) this.unlock('rookie-strike');
+    if (state.flags.campusLeveled) this.unlock('campus-liberator');
+    if (state.flags.aliensTriggered && state.flags.aliensDefeated)
+      this.unlock('counterattack-crushed');
+    if (state.rescue.total > 0 && state.rescue.rescued >= state.rescue.total)
+      this.unlock('evac-ace');
+
+    const missionId = mission.state.def.id;
+
+    if (missionId === 'm01') {
+      const waveObjective = mission.state.objectives.find((o) => o.id === 'obj4');
+      if (waveObjective?.complete) this.unlock('wavebreaker');
+      if (this.ui.state === 'win') this.unlock('dawnshield-complete');
+    } else if (missionId === 'm02') {
+      if (this.ui.state === 'win' && state.boat.boatsEscaped === 0)
+        this.unlock('stormbreak-guardian');
+    } else if (missionId === 'm03') {
+      if (this.ui.state === 'win') this.unlock('starfall-complete');
+    } else if (missionId === 'm04') {
+      if (state.hive.armed) this.unlock('light-the-fuse');
+      if (this.ui.state === 'win') this.unlock('black-sun-complete');
+    }
+  }
+
+  public getRenderState(): AchievementRenderState {
+    return {
+      definitions: ACHIEVEMENTS,
+      unlocked: this.unlocked,
+      banners: this.banners.map((banner) => this.toBannerView(banner)),
+    };
+  }
+
+  public reset(): void {
+    this.unlocked.clear();
+    this.banners.length = 0;
+    this.syncStore();
+  }
+
+  private unlock(id: string): void {
+    if (this.unlocked.has(id)) return;
+    if (!achievementMap.has(id)) return;
+    this.unlocked.add(id);
+    this.syncStore();
+    this.banners.push({ id, age: 0 });
+    while (this.banners.length > 4) this.banners.shift();
+  }
+
+  private updateBanners(dt: number): void {
+    for (let i = this.banners.length - 1; i >= 0; i -= 1) {
+      const banner = this.banners[i]!;
+      banner.age += dt;
+      if (banner.age >= BANNER_LIFETIME) {
+        this.banners.splice(i, 1);
+      }
+    }
+  }
+
+  private syncStore(): void {
+    if (!this.ui.achievements) {
+      this.ui.achievements = { unlocked: [] };
+    }
+    const sorted = Array.from(this.unlocked);
+    sorted.sort((a, b) => {
+      const orderA = ORDER_LOOKUP.get(a) ?? Number.POSITIVE_INFINITY;
+      const orderB = ORDER_LOOKUP.get(b) ?? Number.POSITIVE_INFINITY;
+      if (orderA === orderB) return a.localeCompare(b);
+      return orderA - orderB;
+    });
+    this.ui.achievements.unlocked = sorted;
+    this.saveUI(this.ui);
+  }
+
+  private toBannerView(banner: BannerState): AchievementBannerView {
+    const def = achievementMap.get(banner.id);
+    const title = def?.title ?? banner.id;
+    const description = def?.description ?? '';
+
+    let alpha = 1;
+    if (banner.age < BANNER_FADE_IN) {
+      alpha = Math.max(0, Math.min(1, banner.age / BANNER_FADE_IN));
+    } else if (banner.age > BANNER_LIFETIME - BANNER_FADE_OUT) {
+      const t = (banner.age - (BANNER_LIFETIME - BANNER_FADE_OUT)) / BANNER_FADE_OUT;
+      alpha = Math.max(0, 1 - t);
+    }
+
+    const slideOffset =
+      banner.age < BANNER_FADE_IN ? 1 - Math.min(1, banner.age / BANNER_FADE_IN) : 0;
+
+    return { id: banner.id, title, description, alpha, slideOffset };
+  }
+}
+
+export function createAchievementTracker(deps: AchievementTrackerDeps): AchievementTracker {
+  return new AchievementTracker(deps);
+}

--- a/src/render/scene/gameScene.ts
+++ b/src/render/scene/gameScene.ts
@@ -18,6 +18,7 @@ import { drawPad, drawHeli } from '../../render/sprites/heli';
 import { drawRescueRunner } from '../../render/sprites/rescuees';
 import { drawHUD } from '../../ui/hud/hud';
 import { renderSettings, renderAchievements, renderAbout } from '../../ui/menus/renderers';
+import type { AchievementRenderState } from '../../game/achievements/tracker';
 import type { Menu } from '../../ui/menus/menu';
 import type { UIStore } from '../../ui/menus/scenes';
 import type { MissionTracker } from '../../game/missions/tracker';
@@ -60,6 +61,7 @@ export interface GameSceneRenderArgs {
   player: Entity;
   pad: PadConfig;
   safeHouse: SafeHouseParams;
+  achievements: AchievementRenderState;
   fps: number;
   dt: number;
 }
@@ -70,7 +72,7 @@ export interface GameSceneRenderer {
 
 export function createGameSceneRenderer(deps: GameSceneRendererDeps): GameSceneRenderer {
   const renderMenuScenes = (args: GameSceneRenderArgs): boolean => {
-    const { ui, titleMenu } = args;
+    const { ui, titleMenu, achievements } = args;
     if (ui.state === 'title') {
       titleMenu.render(deps.context, 'Choppa', 'Isometric helicopter action prototype');
       return true;
@@ -80,7 +82,7 @@ export function createGameSceneRenderer(deps: GameSceneRendererDeps): GameSceneR
       return true;
     }
     if (ui.state === 'achievements') {
-      renderAchievements(deps.context);
+      renderAchievements(deps.context, achievements);
       return true;
     }
     if (ui.state === 'about') {
@@ -373,6 +375,7 @@ export function createGameSceneRenderer(deps: GameSceneRendererDeps): GameSceneR
         enemies: state.minimapEnemies,
       },
       isoParams,
+      args.achievements.banners,
     );
 
     if (state.player.invulnerable && ui.state === 'in-game') {


### PR DESCRIPTION
## Summary
- add an achievements catalogue with tracker, persistence, and unlock logic
- surface unlock banners in the HUD and wire tracker updates into the main loop
- rebuild the achievements menu with styled cards that show status and descriptions

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d32872de8c8327b34b193ac0e24b2e