### PR TITLE
Rotate survivor pickups clockwise

### DIFF
--- a/src/render/sprites/pickups.ts
+++ b/src/render/sprites/pickups.ts
@@ -136,7 +136,7 @@ function drawSurvivorPickup(
   drawRescueRunner(ctx, {
     x: baseX,
     y: baseY - lift,
-    angle: Math.PI / 2,
+    angle: (Math.PI * 3) / 2,
     stepPhase,
     bob,
     fade: 1,


### PR DESCRIPTION
## Summary
- rotate survivor pickup sprite orientation 90° clockwise to face the intended direction
- keep rescue runners heading to the safehouse unchanged

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d32cddefe88327af2a1e661da9d21b