### PR TITLE
Add mission power-up selection and tune weapon defaults

### DIFF
--- a/src/game/app/bootstrap.ts
+++ b/src/game/app/bootstrap.ts
@@ -163,6 +163,7 @@ function setupAudio(ui: UIStore): {
     level1: `${audioBase}audio/level1.mp3`,
     level2: `${audioBase}audio/level2.mp3`,
     level3: `${audioBase}audio/level3.mp3`,
+    level4: `${audioBase}level4.mp3`,
   });
   const applySettings = (muted: boolean): void => {
     bus.setMaster(muted ? 0 : ui.settings.masterVolume);

--- a/src/game/app/powerups.ts
+++ b/src/game/app/powerups.ts
@@ -1,0 +1,168 @@
+import type { Ammo } from '../components/Ammo';
+import type { Fuel } from '../components/Fuel';
+import type { WeaponHolder } from '../components/Weapon';
+import {
+  DEFAULT_HELLFIRE_COOLDOWN,
+  DEFAULT_HELLFIRE_DAMAGE,
+  DEFAULT_HELLFIRE_DAMAGE_RADIUS,
+  DEFAULT_HELLFIRE_LAUNCH_OFFSET,
+  DEFAULT_HELLFIRE_PROJECTILE_SPEED,
+  DEFAULT_MACHINE_GUN_COOLDOWN,
+  DEFAULT_MACHINE_GUN_DAMAGE,
+  DEFAULT_MACHINE_GUN_DAMAGE_RADIUS,
+  DEFAULT_MACHINE_GUN_PROJECTILE_SPEED,
+  DEFAULT_ROCKET_COOLDOWN,
+  DEFAULT_ROCKET_DAMAGE,
+  DEFAULT_ROCKET_DAMAGE_RADIUS,
+  DEFAULT_ROCKET_PROJECTILE_SPEED,
+} from '../systems/WeaponFire';
+
+export interface PowerupContext {
+  ammo: Ammo;
+  fuel: Fuel;
+  weapon: WeaponHolder;
+}
+
+export interface PowerupOption {
+  id: string;
+  title: string;
+  description: string;
+  apply: (context: PowerupContext) => void;
+}
+
+export interface PowerupRound {
+  roundLabel: string;
+  options: PowerupOption[];
+}
+
+export const PLAYER_BASE_STATS = {
+  fuelMax: 100,
+  missilesMax: 200,
+  rocketsMax: 12,
+  hellfiresMax: 2,
+  machineGunFireDelay: DEFAULT_MACHINE_GUN_COOLDOWN,
+  rocketFireDelay: DEFAULT_ROCKET_COOLDOWN,
+  hellfireFireDelay: DEFAULT_HELLFIRE_COOLDOWN,
+  machineGunDamage: DEFAULT_MACHINE_GUN_DAMAGE,
+  machineGunDamageRadius: DEFAULT_MACHINE_GUN_DAMAGE_RADIUS,
+  machineGunProjectileSpeed: DEFAULT_MACHINE_GUN_PROJECTILE_SPEED,
+  rocketDamage: DEFAULT_ROCKET_DAMAGE,
+  rocketDamageRadius: DEFAULT_ROCKET_DAMAGE_RADIUS,
+  rocketProjectileSpeed: DEFAULT_ROCKET_PROJECTILE_SPEED,
+  hellfireDamage: DEFAULT_HELLFIRE_DAMAGE,
+  hellfireDamageRadius: DEFAULT_HELLFIRE_DAMAGE_RADIUS,
+  hellfireProjectileSpeed: DEFAULT_HELLFIRE_PROJECTILE_SPEED,
+  hellfireLaunchOffset: DEFAULT_HELLFIRE_LAUNCH_OFFSET,
+} as const;
+
+const applyExtraHellfire = ({ ammo }: PowerupContext): void => {
+  ammo.hellfiresMax += 1;
+  ammo.hellfires = ammo.hellfiresMax;
+};
+
+const applyFuelReserve = ({ fuel }: PowerupContext): void => {
+  fuel.max += 25;
+  fuel.current = fuel.max;
+};
+
+const applyRapidCannon = ({ weapon }: PowerupContext): void => {
+  weapon.machineGunFireDelay = DEFAULT_MACHINE_GUN_COOLDOWN / 2;
+};
+
+const applyDoubleMissileAmmo = ({ ammo }: PowerupContext): void => {
+  ammo.missilesMax = Math.max(1, Math.round(ammo.missilesMax * 2));
+  ammo.missiles = ammo.missilesMax;
+};
+
+const applyRocketReserves = ({ ammo }: PowerupContext): void => {
+  ammo.rocketsMax += 6;
+  ammo.rockets = ammo.rocketsMax;
+};
+
+const applyMachineGunPower = ({ weapon }: PowerupContext): void => {
+  weapon.machineGunDamage = Math.round(DEFAULT_MACHINE_GUN_DAMAGE * 1.5);
+  weapon.machineGunDamageRadius = DEFAULT_MACHINE_GUN_DAMAGE_RADIUS * 1.15;
+};
+
+const applyRocketPower = ({ weapon }: PowerupContext): void => {
+  weapon.rocketDamage = Math.round(DEFAULT_ROCKET_DAMAGE * 1.4 * 10) / 10;
+  weapon.rocketDamageRadius = DEFAULT_ROCKET_DAMAGE_RADIUS * 1.2;
+};
+
+const applyHellfirePower = ({ weapon }: PowerupContext): void => {
+  weapon.hellfireDamage = Math.round(DEFAULT_HELLFIRE_DAMAGE * 1.35);
+  weapon.hellfireDamageRadius = DEFAULT_HELLFIRE_DAMAGE_RADIUS * 1.2;
+};
+
+const roundOneOptions: PowerupOption[] = [
+  {
+    id: 'round1-hellfire',
+    title: '+1 Hellfire',
+    description: 'Add an extra hellfire and reload the launcher.',
+    apply: applyExtraHellfire,
+  },
+  {
+    id: 'round1-fuel',
+    title: 'Aux Fuel Tank',
+    description: 'Install an auxiliary fuel tank for +25 max fuel.',
+    apply: applyFuelReserve,
+  },
+  {
+    id: 'round1-gun-speed',
+    title: 'Rapid Cannon',
+    description: 'Double machine gun rate of fire with enhanced cooling.',
+    apply: applyRapidCannon,
+  },
+];
+
+const roundTwoOptions: PowerupOption[] = [
+  {
+    id: 'round2-hellfire',
+    title: '+1 Hellfire',
+    description: 'Carry an additional hellfire and reload.',
+    apply: applyExtraHellfire,
+  },
+  {
+    id: 'round2-ammo',
+    title: 'Ammo Cache',
+    description: 'Double machine gun ammo reserves.',
+    apply: applyDoubleMissileAmmo,
+  },
+  {
+    id: 'round2-rockets',
+    title: '+6 Missiles',
+    description: 'Load six additional guided missiles.',
+    apply: applyRocketReserves,
+  },
+];
+
+const roundThreeOptions: PowerupOption[] = [
+  {
+    id: 'round3-gun-power',
+    title: 'AP Cannon Rounds',
+    description: 'Boost machine gun impact damage.',
+    apply: applyMachineGunPower,
+  },
+  {
+    id: 'round3-rocket-power',
+    title: 'High-Impact Missiles',
+    description: 'Increase missile warhead yield.',
+    apply: applyRocketPower,
+  },
+  {
+    id: 'round3-hellfire-power',
+    title: 'Thermobaric Hellfires',
+    description: 'Amplify hellfire blast damage.',
+    apply: applyHellfirePower,
+  },
+];
+
+const powerupRounds: Record<string, PowerupRound> = {
+  m02: { roundLabel: 'Round 1', options: roundOneOptions },
+  m03: { roundLabel: 'Round 2', options: roundTwoOptions },
+  m04: { roundLabel: 'Round 3', options: roundThreeOptions },
+};
+
+export function getPowerupRoundForMission(missionId: string): PowerupRound | null {
+  return powerupRounds[missionId] ?? null;
+}

--- a/src/game/components/Weapon.ts
+++ b/src/game/components/Weapon.ts
@@ -5,4 +5,17 @@ export interface WeaponHolder {
   cooldownMissile: number;
   cooldownRocket: number;
   cooldownHellfire: number;
+  machineGunFireDelay?: number;
+  rocketFireDelay?: number;
+  hellfireFireDelay?: number;
+  machineGunDamage?: number;
+  machineGunDamageRadius?: number;
+  machineGunProjectileSpeed?: number;
+  rocketDamage?: number;
+  rocketDamageRadius?: number;
+  rocketProjectileSpeed?: number;
+  hellfireDamage?: number;
+  hellfireDamageRadius?: number;
+  hellfireProjectileSpeed?: number;
+  hellfireLaunchOffset?: number;
 }

--- a/src/game/systems/WeaponFire.ts
+++ b/src/game/systems/WeaponFire.ts
@@ -7,6 +7,25 @@ import type { Ammo } from '../components/Ammo';
 import type { InputSnapshot } from '../../core/input/input';
 import { RNG } from '../../core/util/rng';
 
+export const DEFAULT_MACHINE_GUN_COOLDOWN = 0.1;
+export const DEFAULT_MACHINE_GUN_PROJECTILE_SPEED = 22;
+export const DEFAULT_MACHINE_GUN_PROJECTILE_RADIUS = 0.08;
+export const DEFAULT_MACHINE_GUN_DAMAGE = 8;
+export const DEFAULT_MACHINE_GUN_DAMAGE_RADIUS = 0.12;
+
+export const DEFAULT_ROCKET_COOLDOWN = 0.4;
+export const DEFAULT_ROCKET_PROJECTILE_SPEED = 8.8;
+export const DEFAULT_ROCKET_PROJECTILE_RADIUS = 0.22;
+export const DEFAULT_ROCKET_DAMAGE = 19.2;
+export const DEFAULT_ROCKET_DAMAGE_RADIUS = 0.9;
+
+export const DEFAULT_HELLFIRE_COOLDOWN = 1.25;
+export const DEFAULT_HELLFIRE_PROJECTILE_SPEED = 24;
+export const DEFAULT_HELLFIRE_PROJECTILE_RADIUS = 0.3;
+export const DEFAULT_HELLFIRE_LAUNCH_OFFSET = 0.92;
+export const DEFAULT_HELLFIRE_DAMAGE = 36;
+export const DEFAULT_HELLFIRE_DAMAGE_RADIUS = 1.9;
+
 export type FireEvent =
   | {
       faction: 'player' | 'enemy';
@@ -133,7 +152,8 @@ export class WeaponFireSystem implements System {
       // Machine gun (LMB / Space)
       if (machineGunDown) {
         if (w.cooldownMissile <= 0 && ammo.missiles > 0) {
-          w.cooldownMissile = 0.1;
+          const fireDelay = w.machineGunFireDelay ?? DEFAULT_MACHINE_GUN_COOLDOWN;
+          w.cooldownMissile = fireDelay;
           ammo.missiles = Math.max(0, ammo.missiles - 1);
           const spread = 0.08; // radians
           const jitter = (this.rng.float01() - 0.5) * 2 * spread;
@@ -141,6 +161,10 @@ export class WeaponFireSystem implements System {
           const sn = Math.sin(jitter);
           const dx = dirX * cs - dirY * sn;
           const dy = dirX * sn + dirY * cs;
+          const projectileSpeed =
+            w.machineGunProjectileSpeed ?? DEFAULT_MACHINE_GUN_PROJECTILE_SPEED;
+          const damage = w.machineGunDamage ?? DEFAULT_MACHINE_GUN_DAMAGE;
+          const damageRadius = w.machineGunDamageRadius ?? DEFAULT_MACHINE_GUN_DAMAGE_RADIUS;
           this.eventsOut.push({
             faction: 'player',
             kind: 'missile',
@@ -150,11 +174,11 @@ export class WeaponFireSystem implements System {
             dy,
             spread,
             launchOffset: 0.48,
-            speed: 22,
+            speed: projectileSpeed,
             ttl: 0.6,
-            radius: 0.08,
-            damage: 8,
-            damageRadius: 0.12,
+            radius: DEFAULT_MACHINE_GUN_PROJECTILE_RADIUS,
+            damage,
+            damageRadius,
           });
         }
       }
@@ -162,9 +186,12 @@ export class WeaponFireSystem implements System {
       // Missiles (RMB / Shift)
       if (missileDown) {
         if (w.cooldownRocket <= 0 && ammo.rockets > 0) {
-          w.cooldownRocket = 0.4;
+          const fireDelay = w.rocketFireDelay ?? DEFAULT_ROCKET_COOLDOWN;
+          w.cooldownRocket = fireDelay;
           ammo.rockets = Math.max(0, ammo.rockets - 1);
-          const speed = 8.8;
+          const speed = w.rocketProjectileSpeed ?? DEFAULT_ROCKET_PROJECTILE_SPEED;
+          const damage = w.rocketDamage ?? DEFAULT_ROCKET_DAMAGE;
+          const damageRadius = w.rocketDamageRadius ?? DEFAULT_ROCKET_DAMAGE_RADIUS;
           this.eventsOut.push({
             faction: 'player',
             kind: 'rocket',
@@ -173,9 +200,9 @@ export class WeaponFireSystem implements System {
             vx: dirX * speed,
             vy: dirY * speed,
             ttl: 5.2,
-            radius: 0.22,
-            damage: 19.2,
-            damageRadius: 0.9,
+            radius: DEFAULT_ROCKET_PROJECTILE_RADIUS,
+            damage,
+            damageRadius,
           });
         }
       }
@@ -183,10 +210,13 @@ export class WeaponFireSystem implements System {
       // Hellfires (MMB / Ctrl)
       if (hellfireDown) {
         if (w.cooldownHellfire <= 0 && ammo.hellfires > 0) {
-          w.cooldownHellfire = 1.25;
+          const fireDelay = w.hellfireFireDelay ?? DEFAULT_HELLFIRE_COOLDOWN;
+          w.cooldownHellfire = fireDelay;
           ammo.hellfires = Math.max(0, ammo.hellfires - 1);
-          const speed = 24;
-          const launchOffset = 0.92;
+          const speed = w.hellfireProjectileSpeed ?? DEFAULT_HELLFIRE_PROJECTILE_SPEED;
+          const launchOffset = w.hellfireLaunchOffset ?? DEFAULT_HELLFIRE_LAUNCH_OFFSET;
+          const damage = w.hellfireDamage ?? DEFAULT_HELLFIRE_DAMAGE;
+          const damageRadius = w.hellfireDamageRadius ?? DEFAULT_HELLFIRE_DAMAGE_RADIUS;
           this.eventsOut.push({
             faction: 'player',
             kind: 'hellfire',
@@ -199,9 +229,9 @@ export class WeaponFireSystem implements System {
             targetX: this.aimTileX,
             targetY: this.aimTileY,
             ttl: 3.2,
-            radius: 0.3,
-            damage: 36,
-            damageRadius: 1.9,
+            radius: DEFAULT_HELLFIRE_PROJECTILE_RADIUS,
+            damage,
+            damageRadius,
           });
         }
       }

--- a/src/main.ts
+++ b/src/main.ts
@@ -19,6 +19,11 @@ import type { MissionDef } from './game/missions/types';
 import { createAchievementTracker } from './game/achievements/tracker';
 import { defaultBindings } from './ui/input-remap/bindings';
 import { createUIStore, type UIState, type UIStore } from './ui/menus/scenes';
+import {
+  getPowerupRoundForMission,
+  PLAYER_BASE_STATS,
+  type PowerupOption,
+} from './game/app/powerups';
 
 const bootstrap = bootstrapApp();
 const state = createGameState();
@@ -84,21 +89,34 @@ stores.physics.set(player, {
   maxSpeed: 4.2,
   turnRate: Math.PI * 2,
 });
-stores.fuels.set(player, { current: 65, max: 100 });
+stores.fuels.set(player, { current: 65, max: PLAYER_BASE_STATS.fuelMax });
 stores.sprites.set(player, { color: '#92ffa6', rotor: 0 });
 stores.ammos.set(player, {
-  missiles: 200,
-  missilesMax: 200,
-  rockets: 12,
-  rocketsMax: 12,
-  hellfires: 2,
-  hellfiresMax: 2,
+  missiles: PLAYER_BASE_STATS.missilesMax,
+  missilesMax: PLAYER_BASE_STATS.missilesMax,
+  rockets: PLAYER_BASE_STATS.rocketsMax,
+  rocketsMax: PLAYER_BASE_STATS.rocketsMax,
+  hellfires: PLAYER_BASE_STATS.hellfiresMax,
+  hellfiresMax: PLAYER_BASE_STATS.hellfiresMax,
 });
 stores.weapons.set(player, {
   active: 'missile',
   cooldownMissile: 0,
   cooldownRocket: 0,
   cooldownHellfire: 0,
+  machineGunFireDelay: PLAYER_BASE_STATS.machineGunFireDelay,
+  rocketFireDelay: PLAYER_BASE_STATS.rocketFireDelay,
+  hellfireFireDelay: PLAYER_BASE_STATS.hellfireFireDelay,
+  machineGunDamage: PLAYER_BASE_STATS.machineGunDamage,
+  machineGunDamageRadius: PLAYER_BASE_STATS.machineGunDamageRadius,
+  machineGunProjectileSpeed: PLAYER_BASE_STATS.machineGunProjectileSpeed,
+  rocketDamage: PLAYER_BASE_STATS.rocketDamage,
+  rocketDamageRadius: PLAYER_BASE_STATS.rocketDamageRadius,
+  rocketProjectileSpeed: PLAYER_BASE_STATS.rocketProjectileSpeed,
+  hellfireDamage: PLAYER_BASE_STATS.hellfireDamage,
+  hellfireDamageRadius: PLAYER_BASE_STATS.hellfireDamageRadius,
+  hellfireProjectileSpeed: PLAYER_BASE_STATS.hellfireProjectileSpeed,
+  hellfireLaunchOffset: PLAYER_BASE_STATS.hellfireLaunchOffset,
 });
 stores.healths.set(player, { current: 100, max: 100 });
 stores.colliders.set(player, { radius: 0.4, team: 'player' });
@@ -209,8 +227,16 @@ const missionMusicMap = {
   m01: 'level1',
   m02: 'level2',
   m03: 'level3',
-  m04: 'level3',
+  m04: 'level4',
 } as const;
+
+interface ActivePowerupSelection {
+  roundLabel: string;
+  options: PowerupOption[];
+  highlightedIndex: number;
+}
+
+let activePowerupSelection: ActivePowerupSelection | null = null;
 
 const getMissionTrackId = (missionId: string): string =>
   missionMusicMap[missionId as keyof typeof missionMusicMap] ?? 'level1';
@@ -281,6 +307,44 @@ const playerController = createPlayerController({
   context,
   getStartPosition: () => missionCoordinator.mission.state.def.startPos,
 });
+
+const hasActivePowerupSelection = (): boolean => activePowerupSelection !== null;
+
+const getActivePowerupOptionCount = (): number =>
+  activePowerupSelection ? activePowerupSelection.options.length : 0;
+
+const moveActivePowerupHighlight = (direction: -1 | 1): void => {
+  if (!activePowerupSelection) return;
+  const optionCount = activePowerupSelection.options.length;
+  if (optionCount === 0) return;
+  const nextIndex =
+    (activePowerupSelection.highlightedIndex + direction + optionCount) % optionCount;
+  activePowerupSelection.highlightedIndex = nextIndex;
+};
+
+const setActivePowerupHighlight = (index: number): void => {
+  if (!activePowerupSelection) return;
+  if (index < 0 || index >= activePowerupSelection.options.length) return;
+  activePowerupSelection.highlightedIndex = index;
+};
+
+const confirmActivePowerupSelection = (): boolean => {
+  if (!activePowerupSelection) return false;
+  const { options, highlightedIndex } = activePowerupSelection;
+  const choice = options[highlightedIndex];
+  if (!choice) return false;
+  const ammoComp = stores.ammos.get(player);
+  const fuelComp = stores.fuels.get(player);
+  const weaponComp = stores.weapons.get(player);
+  if (!ammoComp || !fuelComp || !weaponComp) return false;
+  choice.apply({ ammo: ammoComp, fuel: fuelComp, weapon: weaponComp });
+  weaponComp.cooldownMissile = 0;
+  weaponComp.cooldownRocket = 0;
+  weaponComp.cooldownHellfire = 0;
+  activePowerupSelection = null;
+  playerController.resetPlayer();
+  return true;
+};
 
 const pickupProcessor = createPickupProcessor({
   state,
@@ -386,10 +450,56 @@ const resetGame = (targetMissionIndex?: number): void => {
   state.pickupCraneSounds.forEach((handle) => handle.cancel());
   state.pickupCraneSounds.clear();
 
+  const fuelComp = stores.fuels.get(player);
+  if (fuelComp) {
+    fuelComp.max = PLAYER_BASE_STATS.fuelMax;
+    fuelComp.current = fuelComp.max;
+  }
+  const ammoComp = stores.ammos.get(player);
+  if (ammoComp) {
+    ammoComp.missilesMax = PLAYER_BASE_STATS.missilesMax;
+    ammoComp.rocketsMax = PLAYER_BASE_STATS.rocketsMax;
+    ammoComp.hellfiresMax = PLAYER_BASE_STATS.hellfiresMax;
+    ammoComp.missiles = ammoComp.missilesMax;
+    ammoComp.rockets = ammoComp.rocketsMax;
+    ammoComp.hellfires = ammoComp.hellfiresMax;
+  }
+  const weaponComp = stores.weapons.get(player);
+  if (weaponComp) {
+    weaponComp.machineGunFireDelay = PLAYER_BASE_STATS.machineGunFireDelay;
+    weaponComp.rocketFireDelay = PLAYER_BASE_STATS.rocketFireDelay;
+    weaponComp.hellfireFireDelay = PLAYER_BASE_STATS.hellfireFireDelay;
+    weaponComp.machineGunDamage = PLAYER_BASE_STATS.machineGunDamage;
+    weaponComp.machineGunDamageRadius = PLAYER_BASE_STATS.machineGunDamageRadius;
+    weaponComp.machineGunProjectileSpeed = PLAYER_BASE_STATS.machineGunProjectileSpeed;
+    weaponComp.rocketDamage = PLAYER_BASE_STATS.rocketDamage;
+    weaponComp.rocketDamageRadius = PLAYER_BASE_STATS.rocketDamageRadius;
+    weaponComp.rocketProjectileSpeed = PLAYER_BASE_STATS.rocketProjectileSpeed;
+    weaponComp.hellfireDamage = PLAYER_BASE_STATS.hellfireDamage;
+    weaponComp.hellfireDamageRadius = PLAYER_BASE_STATS.hellfireDamageRadius;
+    weaponComp.hellfireProjectileSpeed = PLAYER_BASE_STATS.hellfireProjectileSpeed;
+    weaponComp.hellfireLaunchOffset = PLAYER_BASE_STATS.hellfireLaunchOffset;
+    weaponComp.cooldownMissile = 0;
+    weaponComp.cooldownRocket = 0;
+    weaponComp.cooldownHellfire = 0;
+  }
+
+  activePowerupSelection = null;
+
   fog.reset();
   playerController.resetPlayer();
 
-  transitionUIState('briefing');
+  const powerupRound = getPowerupRoundForMission(scenario.id);
+  if (powerupRound) {
+    activePowerupSelection = {
+      roundLabel: powerupRound.roundLabel,
+      options: powerupRound.options,
+      highlightedIndex: 0,
+    };
+    transitionUIState('powerup-select');
+  } else {
+    transitionUIState('briefing');
+  }
 };
 
 const resetCampaignProgress = (): void => {
@@ -423,6 +533,13 @@ const uiController = createUIController({
   resetCampaign: resetCampaignProgress,
   getNextMissionIndex: () => missionCoordinator.getMissionIndices().next,
   onStateChange: handleUIStateChange,
+  powerups: {
+    hasSelection: hasActivePowerupSelection,
+    getOptionCount: getActivePowerupOptionCount,
+    moveHighlight: (direction: -1 | 1) => moveActivePowerupHighlight(direction),
+    setHighlight: (index: number) => setActivePowerupHighlight(index),
+    confirmSelection: () => confirmActivePowerupSelection(),
+  },
 });
 
 let fps = 0;
@@ -465,6 +582,16 @@ const loop = new GameLoop({
       pad,
       safeHouse,
       achievements: achievementTracker.getRenderState(),
+      powerupSelection: activePowerupSelection
+        ? {
+            roundLabel: activePowerupSelection.roundLabel,
+            highlightedIndex: activePowerupSelection.highlightedIndex,
+            options: activePowerupSelection.options.map((option) => ({
+              title: option.title,
+              description: option.description,
+            })),
+          }
+        : null,
       fps,
       dt: lastStepDt,
     });

--- a/src/render/sprites/targets.ts
+++ b/src/render/sprites/targets.ts
@@ -50,50 +50,87 @@ export function drawAAATurret(
   ctx.ellipse(0, 10, 18, 10, 0, 0, Math.PI * 2);
   ctx.fill();
 
-  ctx.fillStyle = '#1c1030';
+  ctx.fillStyle = '#252a33';
+  ctx.beginPath();
+  ctx.moveTo(-20, 9);
+  ctx.lineTo(0, -3);
+  ctx.lineTo(20, 9);
+  ctx.lineTo(0, 21);
+  ctx.closePath();
+  ctx.fill();
+
+  ctx.fillStyle = '#2f3540';
   ctx.beginPath();
   ctx.moveTo(-16, 8);
-  ctx.lineTo(0, -10);
+  ctx.lineTo(0, 0);
   ctx.lineTo(16, 8);
   ctx.lineTo(0, 16);
   ctx.closePath();
   ctx.fill();
 
-  ctx.strokeStyle = '#63fce0';
-  ctx.lineWidth = 3;
+  ctx.fillStyle = '#414956';
   ctx.beginPath();
-  ctx.ellipse(0, -2, 11, 6, 0, 0, Math.PI * 2);
-  ctx.stroke();
-
-  ctx.fillStyle = '#2a1548';
-  ctx.beginPath();
-  ctx.roundRect(-9, -16, 18, 16, 6);
+  ctx.ellipse(0, -2, 12, 7, 0, 0, Math.PI * 2);
   ctx.fill();
 
-  ctx.fillStyle = '#9bfff1';
-  ctx.beginPath();
-  ctx.arc(0, -8, 5, 0, Math.PI * 2);
-  ctx.fill();
-
-  ctx.strokeStyle = '#c7a4ff';
-  ctx.lineWidth = 3;
-  ctx.beginPath();
-  ctx.moveTo(-11, -3);
-  ctx.lineTo(-20, -11);
-  ctx.moveTo(11, -3);
-  ctx.lineTo(20, -11);
-  ctx.stroke();
-
-  ctx.strokeStyle = '#6dfcdf';
+  ctx.strokeStyle = '#636d7a';
   ctx.lineWidth = 2;
   ctx.beginPath();
-  ctx.moveTo(0, -16);
-  ctx.lineTo(0, -26);
-  ctx.moveTo(-5, -14);
-  ctx.lineTo(-7, -22);
-  ctx.moveTo(5, -14);
-  ctx.lineTo(7, -22);
+  ctx.ellipse(0, -2, 13, 8, 0, 0, Math.PI * 2);
   ctx.stroke();
+
+  ctx.fillStyle = '#1e232b';
+  ctx.beginPath();
+  ctx.roundRect(-11, -15, 22, 14, 5);
+  ctx.fill();
+
+  ctx.fillStyle = '#2a303b';
+  ctx.beginPath();
+  ctx.roundRect(-9, -13, 18, 10, 4);
+  ctx.fill();
+
+  ctx.fillStyle = '#10141a';
+  ctx.beginPath();
+  ctx.roundRect(-6, -12, 12, 8, 3);
+  ctx.fill();
+
+  ctx.fillStyle = '#59616d';
+  ctx.beginPath();
+  ctx.arc(0, -8, 4, 0, Math.PI * 2);
+  ctx.fill();
+
+  ctx.fillStyle = '#4b545f';
+  ctx.beginPath();
+  ctx.arc(-12, 12, 2, 0, Math.PI * 2);
+  ctx.arc(12, 12, 2, 0, Math.PI * 2);
+  ctx.fill();
+
+  ctx.lineCap = 'round';
+  ctx.strokeStyle = '#3b424d';
+  ctx.lineWidth = 6;
+  ctx.beginPath();
+  ctx.moveTo(-5, -10);
+  ctx.lineTo(-13, -24);
+  ctx.moveTo(5, -10);
+  ctx.lineTo(13, -24);
+  ctx.stroke();
+
+  ctx.strokeStyle = '#a3acb9';
+  ctx.lineWidth = 3;
+  ctx.beginPath();
+  ctx.moveTo(-5, -12);
+  ctx.lineTo(-14, -30);
+  ctx.moveTo(5, -12);
+  ctx.lineTo(14, -30);
+  ctx.stroke();
+
+  ctx.fillStyle = '#ccd3db';
+  ctx.beginPath();
+  ctx.arc(-14, -30, 2, 0, Math.PI * 2);
+  ctx.arc(14, -30, 2, 0, Math.PI * 2);
+  ctx.fill();
+
+  ctx.lineCap = 'butt';
   ctx.restore();
 }
 

--- a/src/ui/menus/scenes.ts
+++ b/src/ui/menus/scenes.ts
@@ -3,6 +3,7 @@ export type UIState =
   | 'settings'
   | 'achievements'
   | 'about'
+  | 'powerup-select'
   | 'briefing'
   | 'in-game'
   | 'paused'


### PR DESCRIPTION
## Summary
- add reusable power-up definitions and base player stats for mission resets
- render a pre-briefing power-up selection overlay for missions two through four and apply the chosen bonus
- expose weapon tuning hooks so power-ups can adjust rates of fire and damage values

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d347a43eac83278112e41372d99041