### PR TITLE
Redesign player helicopter sprite

### DIFF
--- a/src/render/sprites/heli.ts
+++ b/src/render/sprites/heli.ts
@@ -33,20 +33,205 @@ export function drawHeli(ctx: CanvasRenderingContext2D, p: HeliDrawParams): void
   ctx.fill();
   ctx.restore();
 
-  // Body
-  ctx.fillStyle = p.color;
-  ctx.strokeStyle = '#142a3a';
+  ctx.lineJoin = 'round';
+
+  // Tail boom
+  ctx.strokeStyle = '#3b4752';
   ctx.lineWidth = 2;
+  ctx.fillStyle = '#07090b';
   ctx.beginPath();
-  ctx.roundRect(-10, -6, 20, 12, 3);
+  ctx.moveTo(-16, -2);
+  ctx.lineTo(-24, -3.2);
+  ctx.lineTo(-24, 3.2);
+  ctx.lineTo(-16, 2);
+  ctx.closePath();
   ctx.fill();
   ctx.stroke();
 
-  // Nose
-  ctx.fillStyle = '#d8f3ff';
+  // Tail fins
+  ctx.fillStyle = '#111a22';
   ctx.beginPath();
-  ctx.arc(10, 0, 3, -0.7, 0.7);
+  ctx.moveTo(-24, -3.2);
+  ctx.lineTo(-29, -1.2);
+  ctx.lineTo(-24, 0);
+  ctx.closePath();
   ctx.fill();
+  ctx.stroke();
+  ctx.beginPath();
+  ctx.moveTo(-24, 3.2);
+  ctx.lineTo(-29, 1.2);
+  ctx.lineTo(-24, 0);
+  ctx.closePath();
+  ctx.fill();
+  ctx.stroke();
+
+  // Tail rotor shroud
+  ctx.save();
+  ctx.translate(-27.5, 0);
+  const tailShroudGradient = ctx.createRadialGradient(0, 0, 0.5, 0, 0, 3.4);
+  tailShroudGradient.addColorStop(0, 'rgba(30, 45, 55, 0.9)');
+  tailShroudGradient.addColorStop(1, 'rgba(10, 12, 15, 0.95)');
+  ctx.fillStyle = tailShroudGradient;
+  ctx.strokeStyle = '#43505b';
+  ctx.lineWidth = 1.2;
+  ctx.beginPath();
+  ctx.arc(0, 0, 3.4, 0, Math.PI * 2);
+  ctx.fill();
+  ctx.stroke();
+
+  // Tail rotor hub and blur
+  ctx.fillStyle = '#8da9bb';
+  ctx.beginPath();
+  ctx.arc(0, 0, 0.9, 0, Math.PI * 2);
+  ctx.fill();
+
+  ctx.strokeStyle = 'rgba(150, 200, 230, 0.65)';
+  ctx.lineWidth = 1.1;
+  const tailBlades = 4;
+  const tailBladeLen = 3.6;
+  for (let i = 0; i < tailBlades; i += 1) {
+    const ang = p.rotorPhase * Math.PI * 4 + (i * Math.PI) / 2;
+    ctx.beginPath();
+    ctx.moveTo(0, 0);
+    ctx.lineTo(Math.cos(ang) * tailBladeLen, Math.sin(ang) * tailBladeLen);
+    ctx.stroke();
+  }
+  ctx.restore();
+
+  // Fuselage core
+  const fuselageGradient = ctx.createLinearGradient(-18, -12, 18, 12);
+  fuselageGradient.addColorStop(0, '#050708');
+  fuselageGradient.addColorStop(0.45, '#111921');
+  fuselageGradient.addColorStop(1, '#202c36');
+  ctx.fillStyle = fuselageGradient;
+  ctx.strokeStyle = '#4a5865';
+  ctx.lineWidth = 2.2;
+  ctx.beginPath();
+  ctx.moveTo(-16, -3);
+  ctx.quadraticCurveTo(-2, -12, 11, -7);
+  ctx.quadraticCurveTo(17, -3, 17, 0);
+  ctx.quadraticCurveTo(17, 3, 11, 7);
+  ctx.quadraticCurveTo(-2, 12, -16, 3);
+  ctx.quadraticCurveTo(-18, 2, -18, 0);
+  ctx.quadraticCurveTo(-18, -2, -16, -3);
+  ctx.closePath();
+  ctx.fill();
+  ctx.stroke();
+
+  // Exhaust housing
+  const exhaustGradient = ctx.createLinearGradient(-18, -5, -10, 5);
+  exhaustGradient.addColorStop(0, '#1b252d');
+  exhaustGradient.addColorStop(1, '#2e3a45');
+  ctx.fillStyle = exhaustGradient;
+  ctx.strokeStyle = '#55616d';
+  ctx.lineWidth = 1.6;
+  ctx.beginPath();
+  ctx.roundRect(-14, -4.5, 4.5, 9, 2);
+  ctx.fill();
+  ctx.stroke();
+
+  // Engine intake
+  const intakeGradient = ctx.createLinearGradient(-7, -6, -1, 6);
+  intakeGradient.addColorStop(0, '#bfcbd4');
+  intakeGradient.addColorStop(0.5, '#f2f7fb');
+  intakeGradient.addColorStop(1, '#7d8892');
+  ctx.fillStyle = intakeGradient;
+  ctx.strokeStyle = '#4f5f6c';
+  ctx.lineWidth = 1.4;
+  ctx.beginPath();
+  ctx.roundRect(-7, -6, 6, 12, 2.5);
+  ctx.fill();
+  ctx.stroke();
+
+  // Upper spine highlight
+  ctx.strokeStyle = 'rgba(180, 200, 220, 0.35)';
+  ctx.lineWidth = 2;
+  ctx.beginPath();
+  ctx.moveTo(-9, -2.5);
+  ctx.quadraticCurveTo(-1, -8, 9, -2);
+  ctx.stroke();
+
+  // Accent stripe
+  ctx.strokeStyle = p.color;
+  ctx.lineWidth = 1.3;
+  ctx.beginPath();
+  ctx.moveTo(-13, 2.4);
+  ctx.quadraticCurveTo(-6, 5.4, 2, 4.2);
+  ctx.stroke();
+
+  // Cockpit glass
+  const canopyGradient = ctx.createLinearGradient(0, -6, 13, 6);
+  canopyGradient.addColorStop(0, 'rgba(125, 210, 255, 0.95)');
+  canopyGradient.addColorStop(0.55, 'rgba(60, 140, 200, 0.85)');
+  canopyGradient.addColorStop(1, 'rgba(25, 70, 120, 0.9)');
+  ctx.fillStyle = canopyGradient;
+  ctx.strokeStyle = 'rgba(150, 220, 255, 0.7)';
+  ctx.lineWidth = 1.8;
+  ctx.beginPath();
+  ctx.moveTo(-2, -5.5);
+  ctx.quadraticCurveTo(9, -10, 14, -3);
+  ctx.quadraticCurveTo(15, 0, 14, 3);
+  ctx.quadraticCurveTo(9, 10, -2, 5.5);
+  ctx.closePath();
+  ctx.fill();
+  ctx.stroke();
+
+  // Canopy frame
+  ctx.strokeStyle = 'rgba(100, 150, 190, 0.65)';
+  ctx.lineWidth = 1.2;
+  ctx.beginPath();
+  ctx.moveTo(2, -4.5);
+  ctx.lineTo(10, 4);
+  ctx.moveTo(2, 4.5);
+  ctx.lineTo(10, -4);
+  ctx.moveTo(6, -7);
+  ctx.lineTo(6, 7);
+  ctx.stroke();
+
+  // Gun pods
+  const gunGradient = ctx.createLinearGradient(6, -8, 18, 8);
+  gunGradient.addColorStop(0, '#0c0f12');
+  gunGradient.addColorStop(1, '#2d353c');
+  ctx.fillStyle = gunGradient;
+  ctx.strokeStyle = '#454f57';
+  ctx.lineWidth = 1.4;
+  ctx.beginPath();
+  ctx.roundRect(6, -7.5, 9, 3.5, 1.8);
+  ctx.fill();
+  ctx.stroke();
+  ctx.beginPath();
+  ctx.roundRect(6, 4, 9, 3.5, 1.8);
+  ctx.fill();
+  ctx.stroke();
+
+  // Gun barrels
+  ctx.fillStyle = '#c3ccd2';
+  ctx.beginPath();
+  ctx.roundRect(15, -6.6, 4.5, 1.4, 0.7);
+  ctx.roundRect(15, 5.2, 4.5, 1.4, 0.7);
+  ctx.fill();
+  ctx.fillStyle = '#7a848c';
+  ctx.fillRect(19.3, -6.2, 3.2, 0.8);
+  ctx.fillRect(19.3, 5.6, 3.2, 0.8);
+
+  // Underbelly lights
+  ctx.fillStyle = '#ffb347';
+  ctx.beginPath();
+  ctx.arc(-2, 7.5, 1.2, 0, Math.PI * 2);
+  ctx.fill();
+  ctx.fillStyle = p.color;
+  ctx.beginPath();
+  ctx.arc(-6, -7.2, 1, 0, Math.PI * 2);
+  ctx.fill();
+
+  // Rotor hub
+  ctx.fillStyle = '#2f3a44';
+  ctx.strokeStyle = '#5d6b75';
+  ctx.lineWidth = 1.5;
+  ctx.beginPath();
+  ctx.arc(0, 0, 3.2, 0, Math.PI * 2);
+  ctx.fill();
+  ctx.stroke();
 
   // Rotor (simple line sweep)
   const bladeLen = 18;


### PR DESCRIPTION
## Summary
- replace the rectangular helicopter body with a fully illustrated black gunship silhouette
- add gradients for fuselage, canopy glass, tail, and engine details for a more realistic look
- draw weapon pods, chrome barrels, accent lighting, and rotor hub to complete the new style
- add a spinning tail rotor assembly to the tail boom for extra detail

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d357312ec883278d74834f1cc97557