### PR TITLE
Play boss and win music cues

### DIFF
--- a/src/game/app/bootstrap.ts
+++ b/src/game/app/bootstrap.ts
@@ -167,6 +167,8 @@ function setupAudio(ui: UIStore): {
     level2: `${audioBase}audio/level2.mp3`,
     level3: `${audioBase}audio/level3.mp3`,
     level4: `${audioBase}level4.mp3`,
+    boss: `${audioBase}audio/boss.mp3`,
+    win: `${audioBase}audio/win.mp3`,
   });
   const applySettings = (muted: boolean): void => {
     bus.setMaster(muted ? 0 : ui.settings.masterVolume);

--- a/src/game/app/update/combat.ts
+++ b/src/game/app/update/combat.ts
@@ -15,6 +15,7 @@ import {
   type EngineSound,
 } from '../../../core/audio/sfx';
 import type { AudioBus } from '../../../core/audio/audio';
+import type { MusicController } from '../../../core/audio/music';
 import type { CameraShake } from '../../../render/camera/shake';
 import type { SystemScheduler } from '../../../core/ecs/systems';
 import type { ProjectilePool } from '../../systems/Projectile';
@@ -38,6 +39,7 @@ export interface CombatProcessorDeps {
   projectilePool: ProjectilePool;
   damage: DamageSystem;
   bus: AudioBus;
+  music: MusicController;
   shake: CameraShake;
   transforms: ComponentStore<Transform>;
   colliders: ComponentStore<Collider>;
@@ -71,6 +73,7 @@ export function createCombatProcessor({
   projectilePool,
   damage,
   bus,
+  music,
   shake,
   transforms,
   colliders,
@@ -400,6 +403,7 @@ export function createCombatProcessor({
         boss.health = bossHealth?.current ?? 0;
         boss.healthMax = bossHealth?.max ?? boss.health;
         boss.phase = 'active';
+        void music.play('boss');
       }
       mission.state.complete = false;
       return;
@@ -562,6 +566,7 @@ export function createCombatProcessor({
     mission.update();
     updateFinalBossPhase(dt);
     if (mission.state.complete && ui.state === 'in-game') {
+      void music.play('win');
       if (mission.state.def.id === 'm04' && state.finalBoss.phase === 'defeated') {
         ui.state = 'final-win';
       } else {

--- a/src/main.ts
+++ b/src/main.ts
@@ -249,6 +249,10 @@ const playMissionTrack = (missionId: string): void => {
 };
 
 const handleUIStateChange = (next: UIState, prev: UIState): void => {
+  if (next === 'win' || next === 'final-win') {
+    void audio.music.play('win');
+    return;
+  }
   if (next === 'title') {
     void audio.music.play('title');
     return;
@@ -385,6 +389,7 @@ const combatProcessor = createCombatProcessor({
   projectilePool,
   damage,
   bus: audio.bus,
+  music: audio.music,
   shake,
   transforms: stores.transforms,
   colliders: stores.colliders,


### PR DESCRIPTION
## Summary
- register boss and win music tracks with the audio controller
- start the boss theme when Vorusk spawns and swap to the win theme on victory
- ensure UI-driven transitions to win states also trigger the win theme

## Testing
- npm run lint *(fails: npm is not available in the container)*

------
https://chatgpt.com/codex/tasks/task_e_68d3fc7df83c83279ae071a8a6869847