### PR TITLE
Align mission three pad with northern start

### DIFF
--- a/src/game/data/missions/mothership_mission.json
+++ b/src/game/data/missions/mothership_mission.json
@@ -9,7 +9,7 @@
   ],
   "startPos": {
     "tx": 30,
-    "ty": 53
+    "ty": 6
   },
   "objectives": [
     {

--- a/src/game/scenarios/layouts.ts
+++ b/src/game/scenarios/layouts.ts
@@ -477,7 +477,7 @@ export function createMissionTwoLayout(): MissionLayout {
 }
 
 export function createMissionThreeLayout(map: { width: number; height: number }): MissionLayout {
-  const pad: PadConfig = { tx: Math.round(map.width / 2), ty: map.height - 7, radius: 1.8 };
+  const pad: PadConfig = { tx: Math.round(map.width / 2), ty: 6, radius: 1.8 };
   const safeHouse: SafeHouseParams = {
     tx: pad.tx - 1.2,
     ty: pad.ty + 0.6,


### PR DESCRIPTION
## Summary
- reposition Operation Starfall's landing pad to tile row 6 so it matches the northern insertion point
- keep the safe house tethered to the pad so it now accompanies the new start location

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d40bfbe40c83278b2138e7cff7d725