### PR TITLE
Play scream when the player dies

### DIFF
--- a/src/game/app/update/combat.ts
+++ b/src/game/app/update/combat.ts
@@ -57,6 +57,7 @@ export interface CombatProcessorDeps {
   spawnAlienUnit: (point: { tx: number; ty: number }) => void;
   spawnFinalBoss: (point: { tx: number; ty: number }) => Entity;
   getRescueCueBuffer?: () => AudioBuffer | null;
+  getPlayerDeathBuffer?: () => AudioBuffer | null;
 }
 
 export interface CombatProcessor {
@@ -91,6 +92,7 @@ export function createCombatProcessor({
   spawnAlienUnit,
   spawnFinalBoss,
   getRescueCueBuffer = () => null,
+  getPlayerDeathBuffer = () => null,
 }: CombatProcessorDeps): CombatProcessor {
   const SHIELD_TAG = 'mothership-shield';
   const MOTHERSHIP_POWER_IDS = ['core-west', 'core-east', 'core-south'] as const;
@@ -154,6 +156,8 @@ export function createCombatProcessor({
     const t = transforms.get(player);
     if (t) spawnExplosion(t.tx, t.ty);
     playExplosion(bus);
+    const deathBuffer = getPlayerDeathBuffer();
+    if (deathBuffer) bus.playSfx(deathBuffer);
     colliders.remove(player);
     const body = physics.get(player);
     if (body) {

--- a/src/main.ts
+++ b/src/main.ts
@@ -61,19 +61,27 @@ const {
 
 const audioBaseUrl = (import.meta.env.BASE_URL ?? '/').replace(/\/?$/, '/');
 const rescueCueUrl = `${audioBaseUrl}audio/GTTC.mp3`;
+const playerScreamUrl = `${audioBaseUrl}audio/scream.mp3`;
 let rescueCueBuffer: AudioBuffer | null = null;
+let playerScreamBuffer: AudioBuffer | null = null;
 
-void (async () => {
+async function loadAudioBuffer(url: string, label: string): Promise<AudioBuffer | null> {
   try {
-    const response = await fetch(rescueCueUrl);
+    const response = await fetch(url);
     if (!response.ok) throw new Error(`HTTP ${response.status}`);
     const arrayBuffer = await response.arrayBuffer();
-    rescueCueBuffer = await new Promise<AudioBuffer>((resolve, reject) => {
+    return await new Promise<AudioBuffer>((resolve, reject) => {
       audio.bus.context.decodeAudioData(arrayBuffer.slice(0), resolve, reject);
     });
   } catch (err) {
-    console.warn('[audio] Failed to load rescue cue', err);
+    console.warn(`[audio] Failed to load ${label}`, err);
+    return null;
   }
+}
+
+void (async () => {
+  rescueCueBuffer = await loadAudioBuffer(rescueCueUrl, 'rescue cue');
+  playerScreamBuffer = await loadAudioBuffer(playerScreamUrl, 'player scream');
 })();
 
 void audio.music.play('title');
@@ -406,6 +414,7 @@ const combatProcessor = createCombatProcessor({
   spawnAlienUnit,
   spawnFinalBoss,
   getRescueCueBuffer: () => rescueCueBuffer,
+  getPlayerDeathBuffer: () => playerScreamBuffer,
 });
 
 setBoatLandingHandler(combatProcessor.handleBoatLanding);


### PR DESCRIPTION
## Summary
- load the scream audio asset alongside other decoded buffers
- expose the buffer to the combat processor and play it when the player dies

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d4252a5a7883279868a99f579b52dd