### PR TITLE
Fix mission 3 conduit objective markers

### DIFF
--- a/src/game/data/missions/mothership_mission.json
+++ b/src/game/data/missions/mothership_mission.json
@@ -17,7 +17,7 @@
       "type": "destroy",
       "name": "Disable the western power conduit",
       "at": {
-        "tx": 5.2,
+        "tx": 24.2,
         "ty": 30.2
       },
       "radiusTiles": 1.8
@@ -27,7 +27,7 @@
       "type": "destroy",
       "name": "Disable the eastern power conduit",
       "at": {
-        "tx": 54.2,
+        "tx": 35.8,
         "ty": 30.0
       },
       "radiusTiles": 1.8
@@ -38,7 +38,7 @@
       "name": "Disable the southern power conduit",
       "at": {
         "tx": 30.0,
-        "ty": 57.2
+        "ty": 38.6
       },
       "radiusTiles": 1.9
     },

--- a/src/game/missions/coordinator.ts
+++ b/src/game/missions/coordinator.ts
@@ -730,8 +730,7 @@ class MissionCoordinatorImpl implements MissionCoordinator {
   private setupMissionTwoHandlers(): void {
     this.missionHandlers.boats = () =>
       this.state.boat.objectiveComplete && !this.state.boat.objectiveFailed;
-    this.missionHandlers.scientists = () =>
-      this.state.rescue.rescued >= this.state.rescue.total;
+    this.missionHandlers.scientists = () => this.state.rescue.rescued >= this.state.rescue.total;
   }
 
   private setupMissionTwoObjectiveLabels(): void {


### PR DESCRIPTION
## Summary
- update Operation Starfall destroy objective coordinates to match the conduit building sites
- adjust mission handler formatting to keep the lint run clean

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d428641a888327afbad3e8e36113fb