### PR TITLE
Scatter additional pickups across mission four

### DIFF
--- a/src/game/missions/coordinator.ts
+++ b/src/game/missions/coordinator.ts
@@ -730,8 +730,7 @@ class MissionCoordinatorImpl implements MissionCoordinator {
   private setupMissionTwoHandlers(): void {
     this.missionHandlers.boats = () =>
       this.state.boat.objectiveComplete && !this.state.boat.objectiveFailed;
-    this.missionHandlers.scientists = () =>
-      this.state.rescue.rescued >= this.state.rescue.total;
+    this.missionHandlers.scientists = () => this.state.rescue.rescued >= this.state.rescue.total;
   }
 
   private setupMissionTwoObjectiveLabels(): void {
@@ -739,9 +738,10 @@ class MissionCoordinatorImpl implements MissionCoordinator {
       const boat = this.state.boat.scenario;
       if (!boat) return objective.name;
       const totalWaves = boat.waves.length;
-      const currentWave = this.state.wave.active
-        ? this.state.wave.index
-        : Math.min(this.state.wave.index + 1, totalWaves);
+      let currentWave = this.state.wave.index;
+      if (!this.state.wave.active) {
+        currentWave = Math.min(this.state.wave.index + 1, totalWaves);
+      }
       let label = `${objective.name} (Escaped: ${this.state.boat.boatsEscaped}/${boat.maxEscapes}`;
       if (!objective.complete) {
         const clampedWave = Math.min(Math.max(currentWave, 1), totalWaves);

--- a/src/game/scenarios/layouts.ts
+++ b/src/game/scenarios/layouts.ts
@@ -863,6 +863,26 @@ export function createMissionFourLayout(map: { width: number; height: number }):
       ammo: { missiles: 142, rockets: 6, hellfires: 3 },
     },
     { tx: pad.tx, ty: pad.ty - 3.0, kind: 'armor', armorAmount: 40 },
+    { tx: 22.5, ty: 23.0, kind: 'fuel', fuelAmount: 70 },
+    { tx: 41.5, ty: 23.0, kind: 'fuel', fuelAmount: 70 },
+    {
+      tx: 26.8,
+      ty: 32.8,
+      kind: 'ammo',
+      ammo: { missiles: 96, rockets: 4, hellfires: 2 },
+    },
+    {
+      tx: 37.2,
+      ty: 32.8,
+      kind: 'ammo',
+      ammo: { missiles: 96, rockets: 4, hellfires: 2 },
+    },
+    {
+      tx: 32.0,
+      ty: 14.8,
+      kind: 'ammo',
+      ammo: { missiles: 110, rockets: 5, hellfires: 2 },
+    },
   ];
 
   const alienSpawnPoints = [


### PR DESCRIPTION
## Summary
- add several ammo and fuel pickup sites across the homeland map to support mission four
- adjust mission two objective label logic formatting to satisfy linting rules

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d429a8105083278819cfb3440b62ce