### PR TITLE
Prevent boss missiles from dealing friendly fire

### DIFF
--- a/src/game/systems/Damage.ts
+++ b/src/game/systems/Damage.ts
@@ -2,7 +2,7 @@ import type { System } from '../../core/ecs/systems';
 import type { ComponentStore } from '../../core/ecs/components';
 import type { Health } from '../components/Health';
 import type { Transform } from '../components/Transform';
-import type { Collider } from '../components/Collider';
+import type { Collider, Team } from '../components/Collider';
 import type { Entity } from '../../core/ecs/entities';
 
 export interface PendingHit {
@@ -10,6 +10,7 @@ export interface PendingHit {
   y: number;
   radius: number;
   amount: number;
+  sourceTeam?: Team;
 }
 
 export class DamageSystem implements System {
@@ -34,6 +35,7 @@ export class DamageSystem implements System {
         const t = this.transforms.get(e);
         const h = this.healths.get(e);
         if (!t || !h || h.current <= 0) return;
+        if (hit.sourceTeam && c.team && c.team === hit.sourceTeam) return;
         const r = (c.radius || 0) + hit.radius;
         const dx = t.tx - hit.x;
         const dy = t.ty - hit.y;

--- a/src/game/systems/Projectile.ts
+++ b/src/game/systems/Projectile.ts
@@ -1,6 +1,6 @@
 import type { ComponentStore } from '../../core/ecs/components';
 import type { Transform } from '../components/Transform';
-import type { Collider } from '../components/Collider';
+import type { Collider, Team } from '../components/Collider';
 import type { DamageTag } from '../components/DamageTag';
 
 export interface Projectile {
@@ -14,6 +14,14 @@ export interface Projectile {
   radius: number; // collision radius
   seek?: { targetX: number; targetY: number; turnRate: number };
   damage: DamageTag;
+}
+
+interface ProjectileImpact {
+  x: number;
+  y: number;
+  radius: number;
+  amount: number;
+  sourceTeam?: Team;
 }
 
 /** Simple projectile pool */
@@ -36,7 +44,7 @@ export class ProjectilePool {
     playerColliders: ComponentStore<Collider>,
     enemyColliders: ComponentStore<Collider>,
     transforms: ComponentStore<Transform>,
-    onHit: (hit: { x: number; y: number; radius: number; amount: number }) => void,
+    onHit: (hit: ProjectileImpact) => void,
   ): void {
     const next: Projectile[] = [];
     for (let i = 0; i < this.items.length; i += 1) {
@@ -73,7 +81,7 @@ export class ProjectilePool {
         if (pr.kind === 'missile' || pr.kind === 'hellfire') {
           const amount = pr.damage.amount;
           const rad = pr.damage.radius ?? 0.05;
-          onHit({ x: pr.x, y: pr.y, radius: rad, amount });
+          onHit({ x: pr.x, y: pr.y, radius: rad, amount, sourceTeam: pr.faction });
         }
         continue; // expired
       }
@@ -98,7 +106,7 @@ export class ProjectilePool {
           hit = true;
           const amount = pr.damage.amount;
           const rad = pr.damage.radius ?? 0.05;
-          onHit({ x: pr.x, y: pr.y, radius: rad, amount });
+          onHit({ x: pr.x, y: pr.y, radius: rad, amount, sourceTeam: pr.faction });
         }
       });
       if (!hit) next.push(pr);


### PR DESCRIPTION
## Summary
- add a sourceTeam flag to projectile impact events
- skip applying area-of-effect damage to entities on the same team

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d42c954eb08327a221fc262388b871