### PR TITLE
Add unique homeland sprites for mission four objectives

### DIFF
--- a/src/game/scenarios/layouts.ts
+++ b/src/game/scenarios/layouts.ts
@@ -751,6 +751,7 @@ export function createMissionFourLayout(map: { width: number; height: number }):
       score: 480,
       category: 'stronghold',
       triggersAlarm: true,
+      tag: 'homeland-synapse-cluster',
     },
     {
       tx: 39.5,
@@ -766,6 +767,7 @@ export function createMissionFourLayout(map: { width: number; height: number }):
       score: 480,
       category: 'stronghold',
       triggersAlarm: true,
+      tag: 'homeland-synapse-cluster',
     },
     {
       tx: 32.0,
@@ -781,6 +783,7 @@ export function createMissionFourLayout(map: { width: number; height: number }):
       score: 500,
       category: 'stronghold',
       triggersAlarm: true,
+      tag: 'homeland-shield-pylon',
     },
   ];
 

--- a/src/render/scene/gameScene.ts
+++ b/src/render/scene/gameScene.ts
@@ -1,7 +1,12 @@
 import type { RuntimeTilemap } from '../../world/tiles/tiled';
 import { isoMapBounds, tileToIso } from '../../render/iso/projection';
 import { getCanvasViewMetrics } from '../../render/canvas/metrics';
-import { drawBuilding, drawMothershipTeslaTower } from '../../render/sprites/buildings';
+import {
+  drawBuilding,
+  drawMothershipTeslaTower,
+  drawShieldPylons,
+  drawSynapseCluster,
+} from '../../render/sprites/buildings';
 import { drawRubble } from '../../render/sprites/rubble';
 import { drawForceFieldDome } from '../../render/sprites/forceField';
 import { drawSafeHouse, type SafeHouseParams } from '../../render/sprites/safehouse';
@@ -150,6 +155,24 @@ export function createGameSceneRenderer(deps: GameSceneRendererDeps): GameSceneR
       const meta = state.buildingMeta.get(entity);
       if (meta?.tag === 'mothership-conduit') {
         drawMothershipTeslaTower(deps.context, isoParams, originWithShakeX, originWithShakeY, {
+          tx: t.tx,
+          ty: t.ty,
+          width: building.width,
+          depth: building.depth,
+          height: building.height,
+          damage01,
+        });
+      } else if (meta?.tag === 'homeland-synapse-cluster') {
+        drawSynapseCluster(deps.context, isoParams, originWithShakeX, originWithShakeY, {
+          tx: t.tx,
+          ty: t.ty,
+          width: building.width,
+          depth: building.depth,
+          height: building.height,
+          damage01,
+        });
+      } else if (meta?.tag === 'homeland-shield-pylon') {
+        drawShieldPylons(deps.context, isoParams, originWithShakeX, originWithShakeY, {
           tx: t.tx,
           ty: t.ty,
           width: building.width,

--- a/src/render/sprites/buildings.ts
+++ b/src/render/sprites/buildings.ts
@@ -21,6 +21,24 @@ export interface TeslaTowerDraw {
   damage01: number;
 }
 
+export interface SynapseClusterDraw {
+  tx: number;
+  ty: number;
+  width: number;
+  depth: number;
+  height: number;
+  damage01: number;
+}
+
+export interface ShieldPylonDraw {
+  tx: number;
+  ty: number;
+  width: number;
+  depth: number;
+  height: number;
+  damage01: number;
+}
+
 export function drawBuilding(
   ctx: CanvasRenderingContext2D,
   iso: IsoParams,
@@ -290,6 +308,341 @@ export function drawMothershipTeslaTower(
     ctx.lineTo(baseRadiusX * 0.05, baseRadiusY * 0.52);
     ctx.closePath();
     ctx.fill();
+  }
+
+  ctx.restore();
+}
+
+export function drawSynapseCluster(
+  ctx: CanvasRenderingContext2D,
+  iso: IsoParams,
+  originX: number,
+  originY: number,
+  params: SynapseClusterDraw,
+): void {
+  const halfW = iso.tileWidth / 2;
+  const halfH = iso.tileHeight / 2;
+  const ix = (params.tx - params.ty) * halfW;
+  const iy = (params.tx + params.ty) * halfH;
+  const x = originX + ix;
+  const y = originY + iy;
+
+  const baseRadiusX = halfW * params.width * 0.62;
+  const baseRadiusY = halfH * params.depth * 0.62;
+  const columnHeight = params.height * 1.08;
+  const damage = Math.max(0, Math.min(1, params.damage01));
+  const integrity = 1 - damage;
+  const now = typeof performance !== 'undefined' ? performance.now() : Date.now();
+  const pulse = 0.6 + 0.4 * Math.sin(now / 360 + params.tx * 0.77 + params.ty * 0.63);
+  const tendrilPulse = 0.4 + 0.6 * Math.sin(now / 540 + params.tx * 0.91 + params.ty * 0.41);
+
+  ctx.save();
+  ctx.translate(x, y);
+
+  ctx.fillStyle = 'rgba(0, 0, 0, 0.34)';
+  ctx.beginPath();
+  ctx.ellipse(0, baseRadiusY * 1.45, baseRadiusX * 1.18, baseRadiusY * 0.96, 0, 0, Math.PI * 2);
+  ctx.fill();
+
+  const fleshShadow = adjustShade('#1c0528', -damage * 32);
+  const fleshMid = adjustShade('#2d0f3d', -damage * 22);
+  const fleshHighlight = adjustShade('#3b1653', -damage * 14);
+
+  const podOffsets = [-baseRadiusX * 0.65, 0, baseRadiusX * 0.65];
+  for (let i = 0; i < podOffsets.length; i += 1) {
+    ctx.save();
+    ctx.translate(podOffsets[i]!, baseRadiusY * 0.08);
+    ctx.scale(1, 0.82);
+    const podGradient = ctx.createRadialGradient(
+      0,
+      -baseRadiusY * 0.2,
+      baseRadiusX * 0.12,
+      0,
+      0,
+      baseRadiusX * 0.7,
+    );
+    podGradient.addColorStop(0, adjustShade('#884fff', -damage * 28));
+    podGradient.addColorStop(0.45, fleshHighlight);
+    podGradient.addColorStop(1, fleshShadow);
+    ctx.fillStyle = podGradient;
+    ctx.beginPath();
+    ctx.ellipse(0, 0, baseRadiusX * 0.58, baseRadiusY * 0.78, 0, 0, Math.PI * 2);
+    ctx.fill();
+    ctx.restore();
+  }
+
+  const bodyGradient = ctx.createRadialGradient(
+    0,
+    -columnHeight * 0.2,
+    baseRadiusX * 0.2,
+    0,
+    -columnHeight * 0.2,
+    baseRadiusX * 0.95,
+  );
+  bodyGradient.addColorStop(0, adjustShade('#7021ff', -damage * 24));
+  bodyGradient.addColorStop(0.5, fleshMid);
+  bodyGradient.addColorStop(1, fleshShadow);
+  ctx.fillStyle = bodyGradient;
+  ctx.beginPath();
+  ctx.moveTo(-baseRadiusX * 0.92, baseRadiusY * 0.28);
+  ctx.bezierCurveTo(
+    -baseRadiusX * 0.7,
+    -baseRadiusY * 0.62,
+    -baseRadiusX * 0.28,
+    -columnHeight * 0.32,
+    0,
+    -columnHeight * 0.2,
+  );
+  ctx.bezierCurveTo(
+    baseRadiusX * 0.28,
+    -columnHeight * 0.32,
+    baseRadiusX * 0.72,
+    -baseRadiusY * 0.62,
+    baseRadiusX * 0.92,
+    baseRadiusY * 0.24,
+  );
+  ctx.quadraticCurveTo(0, baseRadiusY * 1.12, -baseRadiusX * 0.92, baseRadiusY * 0.28);
+  ctx.closePath();
+  ctx.fill();
+
+  const veinColor = hexToRgba('#9dfff4', 0.18 + integrity * 0.36 * pulse);
+  ctx.lineWidth = 2.4;
+  ctx.strokeStyle = veinColor;
+  ctx.beginPath();
+  ctx.moveTo(-baseRadiusX * 0.52, baseRadiusY * 0.22);
+  ctx.quadraticCurveTo(-baseRadiusX * 0.32, -columnHeight * 0.12, 0, -columnHeight * 0.64);
+  ctx.quadraticCurveTo(
+    baseRadiusX * 0.32,
+    -columnHeight * 0.12,
+    baseRadiusX * 0.52,
+    baseRadiusY * 0.18,
+  );
+  ctx.stroke();
+
+  ctx.lineWidth = 1.6;
+  ctx.strokeStyle = hexToRgba('#68f7ff', 0.12 + integrity * 0.28 * tendrilPulse);
+  ctx.beginPath();
+  ctx.moveTo(-baseRadiusX * 0.72, baseRadiusY * 0.46);
+  ctx.bezierCurveTo(
+    -baseRadiusX * 0.55,
+    baseRadiusY * 0.05,
+    -baseRadiusX * 0.4,
+    -columnHeight * 0.3,
+    -baseRadiusX * 0.12,
+    -columnHeight * 0.78,
+  );
+  ctx.stroke();
+  ctx.beginPath();
+  ctx.moveTo(baseRadiusX * 0.72, baseRadiusY * 0.44);
+  ctx.bezierCurveTo(
+    baseRadiusX * 0.55,
+    baseRadiusY * 0.04,
+    baseRadiusX * 0.4,
+    -columnHeight * 0.3,
+    baseRadiusX * 0.12,
+    -columnHeight * 0.78,
+  );
+  ctx.stroke();
+
+  const orbRadius = baseRadiusX * 0.34;
+  const orbGlow = ctx.createRadialGradient(
+    0,
+    -columnHeight,
+    orbRadius * 0.2,
+    0,
+    -columnHeight,
+    orbRadius * 1.5,
+  );
+  orbGlow.addColorStop(0, hexToRgba('#d1ffff', 0.35 + integrity * 0.35));
+  orbGlow.addColorStop(0.45, hexToRgba('#96f9ff', 0.42 + integrity * 0.4));
+  orbGlow.addColorStop(1, hexToRgba('#311047', 0));
+  ctx.fillStyle = orbGlow;
+  ctx.beginPath();
+  ctx.arc(0, -columnHeight, orbRadius * 1.35, 0, Math.PI * 2);
+  ctx.fill();
+
+  ctx.fillStyle = hexToRgba('#c9ffff', 0.45 + integrity * 0.35);
+  ctx.beginPath();
+  ctx.arc(0, -columnHeight, orbRadius * 0.7, 0, Math.PI * 2);
+  ctx.fill();
+
+  if (damage > 0.05) {
+    const scorch = hexToRgba('#07030b', 0.18 + damage * 0.4);
+    ctx.fillStyle = scorch;
+    ctx.beginPath();
+    ctx.moveTo(-baseRadiusX * 0.46, baseRadiusY * 0.52);
+    ctx.lineTo(-baseRadiusX * 0.22, baseRadiusY * 0.35);
+    ctx.lineTo(-baseRadiusX * 0.08, baseRadiusY * 0.7);
+    ctx.closePath();
+    ctx.fill();
+    ctx.beginPath();
+    ctx.moveTo(baseRadiusX * 0.46, baseRadiusY * 0.5);
+    ctx.lineTo(baseRadiusX * 0.24, baseRadiusY * 0.34);
+    ctx.lineTo(baseRadiusX * 0.1, baseRadiusY * 0.68);
+    ctx.closePath();
+    ctx.fill();
+
+    ctx.fillStyle = hexToRgba('#120718', 0.12 + damage * 0.35);
+    ctx.beginPath();
+    ctx.moveTo(-baseRadiusX * 0.18, -columnHeight * 0.1);
+    ctx.lineTo(-baseRadiusX * 0.08, -columnHeight * 0.32);
+    ctx.lineTo(-baseRadiusX * 0.02, baseRadiusY * 0.2);
+    ctx.closePath();
+    ctx.fill();
+    ctx.beginPath();
+    ctx.moveTo(baseRadiusX * 0.18, -columnHeight * 0.12);
+    ctx.lineTo(baseRadiusX * 0.1, -columnHeight * 0.34);
+    ctx.lineTo(baseRadiusX * 0.04, baseRadiusY * 0.18);
+    ctx.closePath();
+    ctx.fill();
+  }
+
+  ctx.restore();
+}
+
+export function drawShieldPylons(
+  ctx: CanvasRenderingContext2D,
+  iso: IsoParams,
+  originX: number,
+  originY: number,
+  params: ShieldPylonDraw,
+): void {
+  const halfW = iso.tileWidth / 2;
+  const halfH = iso.tileHeight / 2;
+  const ix = (params.tx - params.ty) * halfW;
+  const iy = (params.tx + params.ty) * halfH;
+  const x = originX + ix;
+  const y = originY + iy;
+
+  const baseRadiusX = halfW * params.width * 0.68;
+  const baseRadiusY = halfH * params.depth * 0.68;
+  const pylonHeight = params.height * 1.12;
+  const damage = Math.max(0, Math.min(1, params.damage01));
+  const integrity = 1 - damage;
+  const now = typeof performance !== 'undefined' ? performance.now() : Date.now();
+  const pulse = 0.5 + 0.5 * Math.sin(now / 420 + params.tx * 0.84 + params.ty * 0.52);
+
+  ctx.save();
+  ctx.translate(x, y);
+
+  ctx.fillStyle = 'rgba(0, 0, 0, 0.32)';
+  ctx.beginPath();
+  ctx.ellipse(0, baseRadiusY * 1.36, baseRadiusX * 1.12, baseRadiusY * 0.92, 0, 0, Math.PI * 2);
+  ctx.fill();
+
+  const ringGradient = ctx.createRadialGradient(
+    0,
+    baseRadiusY * 0.25,
+    baseRadiusX * 0.1,
+    0,
+    baseRadiusY * 0.25,
+    baseRadiusX * 1.05,
+  );
+  ringGradient.addColorStop(0, hexToRgba('#62f1ff', 0.18 + integrity * 0.22 * pulse));
+  ringGradient.addColorStop(0.45, adjustShade('#140d29', -damage * 18));
+  ringGradient.addColorStop(1, adjustShade('#0c0616', -damage * 26));
+  ctx.fillStyle = ringGradient;
+  ctx.beginPath();
+  ctx.ellipse(0, baseRadiusY * 0.42, baseRadiusX, baseRadiusY * 0.7, 0, 0, Math.PI * 2);
+  ctx.fill();
+
+  ctx.strokeStyle = hexToRgba('#7afcff', 0.16 + integrity * 0.32 * pulse);
+  ctx.lineWidth = 2.4;
+  ctx.beginPath();
+  ctx.ellipse(0, baseRadiusY * 0.42, baseRadiusX * 0.86, baseRadiusY * 0.55, 0, 0, Math.PI * 2);
+  ctx.stroke();
+
+  const pylonAngles = [Math.PI / 6, (Math.PI * 5) / 6, (-Math.PI * 3) / 6];
+  const pylonColor = adjustShade('#201337', -damage * 24);
+  const pylonHighlight = adjustShade('#32214f', -damage * 16);
+
+  const pylonPositions: Array<{ x: number; y: number }> = [];
+  for (let i = 0; i < pylonAngles.length; i += 1) {
+    const angle = pylonAngles[i]!;
+    const px = Math.cos(angle) * baseRadiusX * 0.72;
+    const py = Math.sin(angle) * baseRadiusY * 0.72;
+    pylonPositions.push({ x: px, y: py });
+
+    ctx.save();
+    ctx.translate(px, py);
+    ctx.scale(1, 0.88);
+    ctx.fillStyle = pylonColor;
+    ctx.beginPath();
+    ctx.moveTo(-baseRadiusX * 0.18, baseRadiusY * 0.36);
+    ctx.lineTo(-baseRadiusX * 0.08, -pylonHeight * 0.12);
+    ctx.lineTo(-baseRadiusX * 0.04, -pylonHeight * 0.82);
+    ctx.lineTo(baseRadiusX * 0.04, -pylonHeight * 0.82);
+    ctx.lineTo(baseRadiusX * 0.08, -pylonHeight * 0.12);
+    ctx.lineTo(baseRadiusX * 0.18, baseRadiusY * 0.36);
+    ctx.closePath();
+    ctx.fill();
+
+    ctx.fillStyle = pylonHighlight;
+    ctx.beginPath();
+    ctx.moveTo(-baseRadiusX * 0.06, baseRadiusY * 0.3);
+    ctx.lineTo(-baseRadiusX * 0.02, -pylonHeight * 0.15);
+    ctx.lineTo(-baseRadiusX * 0.01, -pylonHeight * 0.76);
+    ctx.lineTo(baseRadiusX * 0.01, -pylonHeight * 0.76);
+    ctx.lineTo(baseRadiusX * 0.02, -pylonHeight * 0.15);
+    ctx.lineTo(baseRadiusX * 0.06, baseRadiusY * 0.3);
+    ctx.closePath();
+    ctx.fill();
+
+    const capRadius = baseRadiusX * 0.16;
+    const capGlow = ctx.createRadialGradient(
+      0,
+      -pylonHeight * 0.86,
+      capRadius * 0.2,
+      0,
+      -pylonHeight * 0.86,
+      capRadius * 1.4,
+    );
+    capGlow.addColorStop(0, hexToRgba('#deffff', 0.4 + integrity * 0.32));
+    capGlow.addColorStop(0.6, hexToRgba('#70f8ff', 0.45 + integrity * 0.36));
+    capGlow.addColorStop(1, hexToRgba('#2a1d45', 0));
+    ctx.fillStyle = capGlow;
+    ctx.beginPath();
+    ctx.arc(0, -pylonHeight * 0.86, capRadius, 0, Math.PI * 2);
+    ctx.fill();
+
+    ctx.restore();
+  }
+
+  const arcAlpha = 0.24 + integrity * 0.38 * pulse;
+  ctx.strokeStyle = hexToRgba('#7ef7ff', arcAlpha);
+  ctx.lineWidth = 1.8;
+  ctx.beginPath();
+  for (let i = 0; i < pylonPositions.length; i += 1) {
+    const current = pylonPositions[i]!;
+    const next = pylonPositions[(i + 1) % pylonPositions.length]!;
+    const midX = (current.x + next.x) / 2;
+    const midY = (current.y + next.y) / 2 - baseRadiusY * (0.4 + 0.12 * pulse);
+    if (i === 0) {
+      ctx.moveTo(current.x, current.y - baseRadiusY * 0.2);
+    }
+    ctx.quadraticCurveTo(midX, midY, next.x, next.y - baseRadiusY * 0.2);
+  }
+  ctx.closePath();
+  ctx.stroke();
+
+  if (damage > 0.05) {
+    const scorch = hexToRgba('#05030a', 0.2 + damage * 0.35);
+    ctx.fillStyle = scorch;
+    ctx.beginPath();
+    ctx.ellipse(0, baseRadiusY * 0.46, baseRadiusX * 0.7, baseRadiusY * 0.5, 0, 0, Math.PI * 2);
+    ctx.fill();
+
+    ctx.fillStyle = hexToRgba('#120a1f', 0.16 + damage * 0.3);
+    for (let i = 0; i < pylonPositions.length; i += 1) {
+      const pos = pylonPositions[i]!;
+      ctx.beginPath();
+      ctx.moveTo(pos.x - baseRadiusX * 0.08, pos.y + baseRadiusY * 0.2);
+      ctx.lineTo(pos.x - baseRadiusX * 0.02, pos.y - baseRadiusY * 0.05);
+      ctx.lineTo(pos.x + baseRadiusX * 0.02, pos.y - baseRadiusY * 0.05);
+      ctx.lineTo(pos.x + baseRadiusX * 0.08, pos.y + baseRadiusY * 0.2);
+      ctx.closePath();
+      ctx.fill();
+    }
   }
 
   ctx.restore();


### PR DESCRIPTION
## Summary
- tag mission four objective structures so they can render with bespoke art
- add synapse cluster and shield pylon canvas sprite routines with damage feedback and animation
- render the new sprites in place of generic buildings during homeland encounters

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d42c3da4a48327afd78bb2f2c5a600