### PR TITLE
Rotate waiting survivors to face safehouse

### DIFF
--- a/src/render/sprites/pickups.ts
+++ b/src/render/sprites/pickups.ts
@@ -136,7 +136,7 @@ function drawSurvivorPickup(
   drawRescueRunner(ctx, {
     x: baseX,
     y: baseY - lift,
-    angle: (Math.PI * 3) / 2,
+    angle: (Math.PI * 3) / 2 + Math.PI / 2,
     stepPhase,
     bob,
     fade: 1,


### PR DESCRIPTION
## Summary
- rotate the idle survivor pickup runners 90° counter-clockwise so they face the safehouse

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d4315138d88327ab492bfb6eddead0