### PR TITLE
Align mission three power conduits with defensive corners

### DIFF
--- a/src/game/data/missions/mothership_mission.json
+++ b/src/game/data/missions/mothership_mission.json
@@ -17,8 +17,8 @@
       "type": "destroy",
       "name": "Disable the western power conduit",
       "at": {
-        "tx": 24.2,
-        "ty": 30.2
+        "tx": 24.0,
+        "ty": 33.2
       },
       "radiusTiles": 1.8
     },
@@ -27,8 +27,8 @@
       "type": "destroy",
       "name": "Disable the eastern power conduit",
       "at": {
-        "tx": 35.8,
-        "ty": 30.0
+        "tx": 36.0,
+        "ty": 33.2
       },
       "radiusTiles": 1.8
     },
@@ -38,7 +38,7 @@
       "name": "Disable the southern power conduit",
       "at": {
         "tx": 30.0,
-        "ty": 38.6
+        "ty": 36.6
       },
       "radiusTiles": 1.9
     },

--- a/src/game/scenarios/layouts.ts
+++ b/src/game/scenarios/layouts.ts
@@ -509,8 +509,8 @@ export function createMissionThreeLayout(map: { width: number; height: number })
 
   const campusSites: BuildingSite[] = [
     {
-      tx: 24.2,
-      ty: 30.2,
+      tx: 24.0,
+      ty: 33.2,
       width: 2.2,
       depth: 1.6,
       height: 36,
@@ -525,8 +525,8 @@ export function createMissionThreeLayout(map: { width: number; height: number })
       tag: 'mothership-conduit',
     },
     {
-      tx: 35.8,
-      ty: 30.0,
+      tx: 36.0,
+      ty: 33.2,
       width: 2.2,
       depth: 1.6,
       height: 36,
@@ -542,7 +542,7 @@ export function createMissionThreeLayout(map: { width: number; height: number })
     },
     {
       tx: 30.0,
-      ty: 38.6,
+      ty: 36.6,
       width: 2.4,
       depth: 1.6,
       height: 34,


### PR DESCRIPTION
## Summary
- repositioned the Operation Starfall power conduit objectives to the defensive corners of the hangar
- updated the mission three layout so conduit structures spawn at the new corner coordinates

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d4331dd800832795a73b5ee5454abf