### PR TITLE
Align mothership power conduits with hangar edges

### DIFF
--- a/src/game/data/missions/mothership_mission.json
+++ b/src/game/data/missions/mothership_mission.json
@@ -17,8 +17,8 @@
       "type": "destroy",
       "name": "Disable the western power conduit",
       "at": {
-        "tx": 24.0,
-        "ty": 33.2
+        "tx": 19.5,
+        "ty": 35.0
       },
       "radiusTiles": 1.8
     },
@@ -27,8 +27,8 @@
       "type": "destroy",
       "name": "Disable the eastern power conduit",
       "at": {
-        "tx": 36.0,
-        "ty": 33.2
+        "tx": 40.5,
+        "ty": 35.0
       },
       "radiusTiles": 1.8
     },
@@ -38,7 +38,7 @@
       "name": "Disable the southern power conduit",
       "at": {
         "tx": 30.0,
-        "ty": 36.6
+        "ty": 41.0
       },
       "radiusTiles": 1.9
     },

--- a/src/game/scenarios/layouts.ts
+++ b/src/game/scenarios/layouts.ts
@@ -509,8 +509,8 @@ export function createMissionThreeLayout(map: { width: number; height: number })
 
   const campusSites: BuildingSite[] = [
     {
-      tx: 24.0,
-      ty: 33.2,
+      tx: 19.5,
+      ty: 35.0,
       width: 2.2,
       depth: 1.6,
       height: 36,
@@ -525,8 +525,8 @@ export function createMissionThreeLayout(map: { width: number; height: number })
       tag: 'mothership-conduit',
     },
     {
-      tx: 36.0,
-      ty: 33.2,
+      tx: 40.5,
+      ty: 35.0,
       width: 2.2,
       depth: 1.6,
       height: 36,
@@ -542,7 +542,7 @@ export function createMissionThreeLayout(map: { width: number; height: number })
     },
     {
       tx: 30.0,
-      ty: 36.6,
+      ty: 41.0,
       width: 2.4,
       depth: 1.6,
       height: 34,
@@ -693,9 +693,9 @@ export function createMissionThreeLayout(map: { width: number; height: number })
   ];
 
   const sentinelPosts: SentinelPost[] = [
-    { tx: 24.0, ty: 33.2, holdRadius: 1.0, leashRange: 7.6, fireRange: 8.0 },
-    { tx: 36.0, ty: 33.2, holdRadius: 1.0, leashRange: 7.6, fireRange: 8.0 },
-    { tx: 30.0, ty: 36.6, holdRadius: 1.1, leashRange: 8.4, fireRange: 8.4 },
+    { tx: 19.5, ty: 35.0, holdRadius: 1.0, leashRange: 7.6, fireRange: 8.0 },
+    { tx: 40.5, ty: 35.0, holdRadius: 1.0, leashRange: 7.6, fireRange: 8.0 },
+    { tx: 30.0, ty: 41.0, holdRadius: 1.1, leashRange: 8.4, fireRange: 8.4 },
     { tx: 30.0, ty: 24.8, holdRadius: 1.0, leashRange: 7.6, fireRange: 8.6 },
   ];
 


### PR DESCRIPTION
## Summary
- retarget the Operation Starfall power conduit objectives to the hangar edge coordinates
- move the mothership conduit building sites and sentry posts to match the corrected positions

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d434cb62b88327bee77d149e3766a3