### PR TITLE
Fix survivor pickup orientation

### DIFF
--- a/src/render/sprites/pickups.ts
+++ b/src/render/sprites/pickups.ts
@@ -136,7 +136,7 @@ function drawSurvivorPickup(
   drawRescueRunner(ctx, {
     x: baseX,
     y: baseY - lift,
-    angle: (Math.PI * 3) / 2 + Math.PI / 2,
+    angle: Math.PI,
     stepPhase,
     bob,
     fade: 1,


### PR DESCRIPTION
## Summary
- ensure survivor pickups render with a 180° rotation so waiting survivors are no longer upside down

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d43d15c6bc83279247f3a06eae7838