### PR TITLE
Revamp HUD objective styling

### DIFF
--- a/src/render/scene/gameScene.ts
+++ b/src/render/scene/gameScene.ts
@@ -26,6 +26,7 @@ import { drawPad, drawHeli, drawCrashSite } from '../../render/sprites/heli';
 import { PLAYER_RESPAWN_DURATION } from '../../game/app/constants';
 import { drawRescueRunner } from '../../render/sprites/rescuees';
 import { drawHUD } from '../../ui/hud/hud';
+import type { ObjectiveLine } from '../../ui/hud/hud';
 import { renderSettings, renderAchievements, renderAbout } from '../../ui/menus/renderers';
 import type { AchievementRenderState } from '../../game/achievements/tracker';
 import type { Menu } from '../../ui/menus/menu';
@@ -453,10 +454,10 @@ export function createGameSceneRenderer(deps: GameSceneRendererDeps): GameSceneR
     const ammoComp = stores.ammos.get(player)!;
     const healthComp = stores.healths.get(player)!;
 
-    const objectiveLines = mission.state.objectives.map((objective) => {
+    const objectiveLines: ObjectiveLine[] = mission.state.objectives.map((objective) => {
       const labelFn = objectiveLabels[objective.id];
       const label = labelFn ? labelFn(objective) : objective.name;
-      return `${objective.complete ? '[x]' : '[ ]'} ${label}`;
+      return { label, complete: objective.complete };
     });
 
     const nextWaveCountdown =


### PR DESCRIPTION
## Summary
- add an ObjectiveLine model for the HUD and feed it from the mission renderer
- redraw the objectives panel with glowing checkboxes and improved typography

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d43c8cd6c88327a864a6e0917f8f60