### PR TITLE
Add ammo crate drops for defeated alien units

### DIFF
--- a/src/game/app/update/combat.ts
+++ b/src/game/app/update/combat.ts
@@ -52,6 +52,7 @@ export interface CombatProcessorDeps {
   missionCoordinator: MissionCoordinator;
   spawnSurvivors: (sites: SurvivorSite[]) => void;
   spawnPickupDrop: (tx: number, ty: number, amount: number) => void;
+  maybeSpawnAlienAmmoDrop: (tx: number, ty: number) => void;
   destroyEntity: (entity: Entity) => void;
   engine: EngineSound;
   spawnAlienUnit: (point: { tx: number; ty: number }) => void;
@@ -88,6 +89,7 @@ export function createCombatProcessor({
   missionCoordinator,
   spawnSurvivors,
   spawnPickupDrop,
+  maybeSpawnAlienAmmoDrop,
   destroyEntity,
   engine,
   spawnAlienUnit,
@@ -197,7 +199,12 @@ export function createCombatProcessor({
       const enemyMeta = state.enemyMeta.get(entity);
       if (enemyMeta) {
         const t = transforms.get(entity);
-        if (t) spawnExplosion(t.tx, t.ty);
+        if (t) {
+          spawnExplosion(t.tx, t.ty);
+          if (state.alienEntities.has(entity)) {
+            maybeSpawnAlienAmmoDrop(t.tx, t.ty);
+          }
+        }
         playExplosion(bus);
         if (enemyMeta.kind === 'boss') {
           state.finalBoss.phase = 'defeated';

--- a/src/main.ts
+++ b/src/main.ts
@@ -405,6 +405,16 @@ const spawnPickupDrop = (tx: number, ty: number, amount: number): void => {
   });
 };
 
+const maybeSpawnAlienAmmoDrop = (tx: number, ty: number): void => {
+  if (rng.float01() > 0.1) return;
+  spawnPickupEntity({
+    tx,
+    ty,
+    kind: 'ammo',
+    ammo: { missiles: 80, rockets: 3, hellfires: 0 },
+  });
+};
+
 const combatProcessor = createCombatProcessor({
   state,
   ui,
@@ -426,6 +436,7 @@ const combatProcessor = createCombatProcessor({
   missionCoordinator,
   spawnSurvivors,
   spawnPickupDrop,
+  maybeSpawnAlienAmmoDrop,
   destroyEntity,
   engine: audio.engine,
   spawnAlienUnit,


### PR DESCRIPTION
## Summary
- add a seeded ammo drop callback that spawns an ammo pickup with standard payload
- hook the combat processor into the new callback so alien deaths roll a 10% drop chance

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d43f97c57c8327bf9d2a2bef4b62a4