### PR TITLE
Adjust nuke planting objective position

### DIFF
--- a/src/game/data/missions/homeland_mission.json
+++ b/src/game/data/missions/homeland_mission.json
@@ -35,7 +35,7 @@
       "type": "custom",
       "name": "Plant the nuke in the hivemind well",
       "requires": ["spire-west", "spire-east", "core-shield"],
-      "at": { "tx": 32.0, "ty": 21.0 },
+      "at": { "tx": 32.0, "ty": 31.0 },
       "radiusTiles": 2.2
     },
     {


### PR DESCRIPTION
## Summary
- move the Operation Black Sun nuke planting objective 10 tiles south to realign with the desired core location

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d4482467808327b9d3ff8b24278fc9